### PR TITLE
Implement karma ban

### DIFF
--- a/config/config.template.py
+++ b/config/config.template.py
@@ -28,6 +28,9 @@ class Config:
         self.max_dice_groups = 10
         self.max_dice_sides = 10000
 
+        # Karma
+        self.karma_ban_role_id = 0
+
         # Voting
         self.vote_minimum = 20
         self.vote_minutes = 2

--- a/repository/reaction.py
+++ b/repository/reaction.py
@@ -95,7 +95,8 @@ class Reaction(BaseRepository):
             if emoji not in ["✅", "❌", "0⃣"]:
                 await message.remove_reaction(emoji, member)
         elif member.id != message.author.id and\
-                guild.id == self.config.guild_id:
+                guild.id == self.config.guild_id and\
+                not member.roles.has(self.config.karma_ban_role_id):
             if type(emoji) is str:
                 self.karma.karma_emoji(message.author, emoji)
             else:
@@ -131,7 +132,8 @@ class Reaction(BaseRepository):
                                                        guild)
                     break
         elif member.id != message.author.id and\
-                guild.id == self.config.guild_id:
+                guild.id == self.config.guild_id and\
+                not member.roles.has(self.config.karma_ban_role_id):
             if type(emoji) is str:
                 self.karma.karma_emoji_remove(message.author, emoji)
             else:


### PR DESCRIPTION
Implements a karma ban that is used by giving a specific role to a user (ID is defined in the config, don't forget to change that), which disallows them from giving or taking away karma