### PR TITLE
Allow bot messages in rooms other than bot-room

### DIFF
--- a/config/config.template.py
+++ b/config/config.template.py
@@ -57,7 +57,6 @@ class Config:
             self.bot_room,
             self.log_channel_id
         ]
-        self.channel_redirect_message = "{} 👉 <#{}>"
 
         # Arcas
         self.arcas_id = 140547421733126145

--- a/config/config.template.py
+++ b/config/config.template.py
@@ -52,6 +52,13 @@ class Config:
         self.vote_message = 'Hlasovani o karma ohodnoceni emotu'
         self.bot_room = 461549842896781312
 
+        # Allowed room check
+        self.allowed_channels = [
+            self.bot_room,
+            self.log_channel_id
+        ]
+        self.channel_redirect_message = "{} 👉 <#{}>"
+
         # Arcas
         self.arcas_id = 140547421733126145
 

--- a/config/messages.py
+++ b/config/messages.py
@@ -4,6 +4,9 @@ class Messages:
         self.server_warning = "Tohle funguje jen na VUT FIT serveru."
         self.toaster_pls = "Toaster pls, máš bordel v DB."
 
+        self.botroom_redirect = "{} <:sadcat:576171980118687754> 👉 " \
+                                "<#{}>\n"
+
         self.karma_own = "{user}, tvoje karma je: **{karma}** (**{pos}.**)."
         self.karma_given = "{user}, rozdal jsi:\n" \
                            "**{karma_pos}** pozitivní karmy " \

--- a/rubbergod.py
+++ b/rubbergod.py
@@ -2,12 +2,13 @@ import discord
 from discord.ext import commands
 from repository import (rng, karma, user, utils, roll_dice,
                         reaction, verification, presence)
-from config import config
+from config import config, messages
 import mysql.connector
 import traceback
 import datetime
 
 config = config.Config()
+messages = messages.Messages()
 bot = commands.Bot(command_prefix=config.command_prefix,
                    help_command=None,
                    case_insensitive=True)
@@ -46,7 +47,7 @@ async def update_web():
 async def botroom_check(message):
     room = await get_room(message)
     if room is not None and room.id not in config.allowed_channels:
-        await message.channel.send(config.channel_redirect_message.format(
+        await message.channel.send(messages.botroom_redirect.format(
             utils.generate_mention(message.author.id),
             config.bot_room))
 

--- a/rubbergod.py
+++ b/rubbergod.py
@@ -45,12 +45,10 @@ async def update_web():
 
 async def botroom_check(message):
     room = await get_room(message)
-    if room is not None and room.id != config.bot_room:
-        await message.channel.send(
-            "{} <:sadcat:576171980118687754> 👉 "
-            "<#{}>\n"
-            .format(utils.generate_mention(message.author.id),
-                    config.bot_room))
+    if room is not None and room.id not in config.allowed_channels:
+        await message.channel.send(config.channel_redirect_message.format(
+            utils.generate_mention(message.author.id),
+            config.bot_room))
 
 
 async def get_room(message):
@@ -127,7 +125,7 @@ async def on_typing(channel, user, when):
         gif = discord.Embed()
         gif.set_image(url="https://i.imgur.com/v2ueHcl.gif")
         await channel.send(embed=gif)
-            
+
 
 #                                      #
 #              COMMANDS                #


### PR DESCRIPTION
Allows specifying which rooms are okay for the bot, moves bot-room redirect message to config
Resolves #19 