### PR TITLE
Make uhoh faster

### DIFF
--- a/config/config.template.py
+++ b/config/config.template.py
@@ -74,4 +74,4 @@ class Config:
 
 
     # uh oh
-    uhoh_regex = re.compile('uh oh', re.IGNORECASE) 
+    uhoh_string = 'uh oh'

--- a/rubbergod.py
+++ b/rubbergod.py
@@ -169,7 +169,7 @@ async def on_message(message):
         await reaction.message_role_reactions(message, role_data)
     elif message.content == "PR":
         await message.channel.send(messages.pr_meme)
-    elif config.uhoh_regex.search(message.content) is not None:
+    elif config.uhoh_string in message.content.lower():
         await message.channel.send(messages.uhoh)
         uhoh_counter += 1
     else:


### PR DESCRIPTION
After doing some testing, I found that `'uh oh' in message.lower()` is much faster than regex in most situations, here's some timings for 1.000.000 loops
```
string tested
'uh oh' in message.lower()
regex search 'uh oh' in message
regex match '^.*uh oh.*$' in message
```
```
'uh oh'
0.1317589
0.3485927
0.4204242

'uh oh '*100
0.3728719
0.3522985
0.6723283

'a'*500 + 'uh oh'
0.4225798
4.3999496
0.5864391

'a'*500 + 'uh oh' + 'a'*500
0.5828917
4.4007902
5.062168

'a'*1000
0.6251828
8.2081621
9.0072494

'xh oh ux oh uhxoh uh xh uh ox '*100
2.4949878
37.8629044
39.403863
```