### PR TITLE
WIP: Template engine concept

### DIFF
--- a/cogs/acl.py
+++ b/cogs/acl.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 
 import utils
+from utils import fill_message
 from cogs import room_check
 from features import acl
 from config import config, messages
@@ -29,9 +30,7 @@ class Acl(commands.Cog):
                                          name="Mod")
         if self.mod in ctx.author.roles:
             if not len(args):
-                await ctx.send(
-                    messages.acl_help
-                    .format(user=utils.generate_mention(ctx.author.id)))
+                await ctx.send(fill_message("acl_help", user=ctx.author.id))
                 return
             if args[0] == 'add':
                 await acl.handle_add(ctx, args[1:])
@@ -42,14 +41,11 @@ class Acl(commands.Cog):
             elif args[0] == 'list':
                 await acl.handle_list(ctx, args[1:])
             else:
-                await ctx.send(
-                    messages.acl_help
-                    .format(user=utils.generate_mention(ctx.author.id)))
+                await ctx.send(fill_message("acl_help", user=ctx.author.id))
                 return
         else:
             await ctx.send(
-                messages.missing_perms
-                .format(user=utils.generate_mention(ctx.author.id)))
+                await ctx.send(fill_message("missing_perms", user=ctx.author.id))
             return
 
     # TODO: this is only to help init the acl database

--- a/cogs/acl.py
+++ b/cogs/acl.py
@@ -4,13 +4,12 @@ from discord.ext import commands
 import utils
 from cogs import room_check
 from features import acl
-from config import config, messages
+from config import config
 from repository import acl_repo
 
 acl_repo = acl_repo.AclRepository()
 acl = acl.Acl(acl_repo)
 config = config.Config
-messages = messages.Messages
 
 
 class Acl(commands.Cog):

--- a/cogs/acl.py
+++ b/cogs/acl.py
@@ -63,7 +63,7 @@ class Acl(commands.Cog):
             for role in guild.roles:
                 if str(role.id) not in rules and role < rubbergod:
                     output += str(role.name) + "  -  " + str(role.id) + "\n"
-                    
+
             await ctx.send(output + "\n```")
 
 

--- a/cogs/acl.py
+++ b/cogs/acl.py
@@ -2,7 +2,6 @@ import discord
 from discord.ext import commands
 
 import utils
-from utils import fill_message
 from cogs import room_check
 from features import acl
 from config import config, messages
@@ -30,7 +29,7 @@ class Acl(commands.Cog):
                                          name="Mod")
         if self.mod in ctx.author.roles:
             if not len(args):
-                await ctx.send(fill_message("acl_help", user=ctx.author.id))
+                await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
                 return
             if args[0] == 'add':
                 await acl.handle_add(ctx, args[1:])
@@ -41,11 +40,10 @@ class Acl(commands.Cog):
             elif args[0] == 'list':
                 await acl.handle_list(ctx, args[1:])
             else:
-                await ctx.send(fill_message("acl_help", user=ctx.author.id))
+                await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
                 return
         else:
-            await ctx.send(
-                await ctx.send(fill_message("missing_perms", user=ctx.author.id))
+            await ctx.send(utils.fill_message("missing_perms", user=ctx.author.id))
             return
 
     # TODO: this is only to help init the acl database

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -5,6 +5,7 @@ import discord
 from discord.ext import commands
 
 import utils
+from utils import fill_message
 from config import config, messages
 from logic import rng
 from features import reaction
@@ -40,9 +41,7 @@ class Base(commands.Cog):
                 await ctx.send(messages.no_such_command)
             return
         elif isinstance(error, commands.CommandOnCooldown):
-            await ctx.send(messages.spamming.format(
-                user=utils.generate_mention(ctx.author.id)
-                ))
+            await ctx.send(fill_message("spamming", user=ctx.author.id))
         else:
             output = 'Ignoring exception in command {}:\n'.format(ctx.command)
             output += ''.join(traceback.format_exception(type(error),
@@ -93,7 +92,8 @@ class Base(commands.Cog):
 
     @commands.command()
     async def kachna_switch(self, ctx):   
-        message = messages.insufficient_rights.format(user=utils.generate_mention(ctx.author.id))
+        message = fill_message("insufficient_rights", user=ctx.author.id)
+
         if ctx.author.id == config.admin_id:
             if config.kachna_temp_closed == False:
                 config.kachna_temp_closed = True

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -77,19 +77,19 @@ class Base(commands.Cog):
         open_date = next_weekday(now, open_days[0])
         for open_day in open_days:
             current_open_date = next_weekday(now, open_day)
-            if current_open_date <= open_date: 
+            if current_open_date <= open_date:
                 open_date = current_open_date
         opentime = open_date.replace(hour=open_hour, minute=0, second=0)
         isClosed = (now < opentime) or (opentime.replace(hour=close_hour) < now)
         delta = opentime - now
-        message = utils.fill_message("kachna_remaining", zbyva=str(delta) if \
+        message = utils.fill_message("kachna_remaining", zbyva=str(delta) if
                                      isClosed else messages.kachna_opened)
         if temp_closed:
             message = messages.kachna_temp_closed
         await ctx.send(message)
 
     @commands.command()
-    async def kachna_switch(self, ctx):   
+    async def kachna_switch(self, ctx):
         message = utils.fill_message("insufficient_rights", user=ctx.author.id)
 
         if ctx.author.id == config.admin_id:

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -5,7 +5,6 @@ import discord
 from discord.ext import commands
 
 import utils
-from utils import fill_message
 from config import config, messages
 from logic import rng
 from features import reaction
@@ -41,7 +40,7 @@ class Base(commands.Cog):
                 await ctx.send(messages.no_such_command)
             return
         elif isinstance(error, commands.CommandOnCooldown):
-            await ctx.send(fill_message("spamming", user=ctx.author.id))
+            await ctx.send(utils.fill_message("spamming", user=ctx.author.id))
         else:
             output = 'Ignoring exception in command {}:\n'.format(ctx.command)
             output += ''.join(traceback.format_exception(type(error),
@@ -92,7 +91,7 @@ class Base(commands.Cog):
 
     @commands.command()
     async def kachna_switch(self, ctx):   
-        message = fill_message("insufficient_rights", user=ctx.author.id)
+        message = utils.fill_message("insufficient_rights", user=ctx.author.id)
 
         if ctx.author.id == config.admin_id:
             if config.kachna_temp_closed == False:

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -58,10 +58,8 @@ class Base(commands.Cog):
     async def uptime(self, ctx):
         now = datetime.datetime.now().replace(microsecond=0)
         delta = now - boottime
-        await ctx.send(
-                messages.uptime_message
-                .format(boottime=str(boottime), uptime=str(delta))
-                )
+        await ctx.send(utils.fill_message("uptime_message", boottime=str(boottime), uptime=str(delta)))
+
     @commands.command()
     async def kachna(self, ctx):
         open_days = config.kachna_open_days
@@ -84,7 +82,8 @@ class Base(commands.Cog):
         opentime = open_date.replace(hour=open_hour, minute=0, second=0)
         isClosed = (now < opentime) or (opentime.replace(hour=close_hour) < now)
         delta = opentime - now
-        message = messages.kachna_remaining.format(zbyva=str(delta)) if isClosed else messages.kachna_opened
+        message = utils.fill_message("kachna_remaining", zbyva=str(delta) if \
+                                     isClosed else messages.kachna_opened)
         if temp_closed:
             message = messages.kachna_temp_closed
         await ctx.send(message)
@@ -96,10 +95,10 @@ class Base(commands.Cog):
         if ctx.author.id == config.admin_id:
             if config.kachna_temp_closed == False:
                 config.kachna_temp_closed = True
-                message = messages.kachna_switched.format(open_closed = "zavřená dlouhodobě")
+                message = utils.fill_message("kachan_switched", open_closed="zavřená dlouhodobě")
             else:
                 config.kachna_temp_closed = False
-                message = messages.kachna_switched.format(open_closed = "otevřená pravidelně")
+                message = utils.fill_message("kachna_switched", open_closed="otevřená pravidelně")
         await ctx.send(message)
 
     @commands.cooldown(rate=2, per=20.0, type=commands.BucketType.user)

--- a/cogs/fitwide.py
+++ b/cogs/fitwide.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 
 
 import utils
-from config import config, messages
+from config import config
 from features import verification
 from repository import user_repo
 from repository.database import database, session
@@ -16,7 +16,6 @@ from repository.database.year_increment import User_backup
 user_r = user_repo.UserRepository()
 
 config = config.Config
-messages = messages.Messages
 arcas_time = (datetime.datetime.utcnow() -
               datetime.timedelta(hours=config.arcas_delay))
 

--- a/cogs/fitwide.py
+++ b/cogs/fitwide.py
@@ -107,7 +107,7 @@ class FitWide(commands.Cog):
                                 await member.add_roles(correct_role)
                                 await member.remove_roles(role)
                                 await ctx.send("Presouvam: " + member.display_name +
-                                               " z " + role_name + " do "+ year)
+                                               " z " + role_name + " do " + year)
                                 break
                     elif p_role:
                         await ctx.send("Nesedi mi role u: " +
@@ -329,7 +329,6 @@ class FitWide(commands.Cog):
         else:
             await ctx.send(result.login)
         
-
     @commands.cooldown(rate=2, per=20.0, type=commands.BucketType.user)
     @commands.check(is_in_modroom)
     @commands.command()
@@ -381,7 +380,7 @@ class FitWide(commands.Cog):
     @update_db.error
     async def fitwide_checks_error(self, ctx, error):
         if isinstance(error, commands.CheckFailure):
-            await ctx.send('Nothing to see here comrade. ' + 
+            await ctx.send('Nothing to see here comrade. ' +
                            '<:KKomrade:484470873001164817>')
 
 def setup(bot):

--- a/cogs/karma.py
+++ b/cogs/karma.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 
 import utils
+from utils import fill_message
 from config import messages, config
 from features import karma, reaction
 from repository import karma_repo
@@ -54,9 +55,7 @@ class Karma(commands.Cog):
                 target_member = await converter.convert(
                         ctx=ctx, argument=' '.join(args[1:]))
             except commands.errors.BadArgument:
-                await ctx.send(
-                    messages.member_not_found
-                    .format(user=utils.generate_mention(ctx.author.id)))
+                await ctx.send(fill_message("member_not_found", user=ctx.author.id))
                 return
 
             await ctx.send(karma.karma_get(ctx.author, target_member))
@@ -64,8 +63,7 @@ class Karma(commands.Cog):
 
         elif args[0] == "get":
             if not await self.check.guild_check(ctx.message):
-                await ctx.send(
-                    "{}".format(messages.server_warning))
+                await ctx.send(messages.server_warning)
             else:
                 try:
                     await karma.emoji_get_value(ctx.message)
@@ -113,13 +111,9 @@ class Karma(commands.Cog):
             if ctx.author.id == config.admin_id:
                 await karma.karma_give(ctx.message)
             else:
-                await ctx.send(
-                    messages.insufficient_rights
-                    .format(user=utils.generate_mention(ctx.author.id)))
+                await ctx.send(fill_message("insufficient_rights", user=ctx.author.id))
         else:
-            await ctx.send(
-                messages.karma_invalid_command
-                .format(utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("karma_invalid_command", user=ctx.author.id))
 
     @commands.cooldown(rate=2, per=30.0, type=commands.BucketType.user)
     @commands.command()
@@ -127,9 +121,7 @@ class Karma(commands.Cog):
         if (not 0 < start < 100000000): # Any value larger than the server
                                         # user cnt and lower than 32bit
                                         # int max will do
-            await ctx.send(
-                messages.karma_lederboard_offser_error
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
             return
         await self.karma.leaderboard(ctx.message.channel, 'get', 'DESC', start)
         await self.check.botroom_check(ctx.message)
@@ -140,9 +132,7 @@ class Karma(commands.Cog):
         if (not 0 < start < 100000000): # Any value larger than the server
                                         # user cnt and lower than 32bit
                                         # int max will do
-            await ctx.send(
-                messages.karma_lederboard_offser_error
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
             return
         await self.karma.leaderboard(ctx.message.channel, 'get', 'ASC', start)
         await self.check.botroom_check(ctx.message)
@@ -153,9 +143,7 @@ class Karma(commands.Cog):
         if (not 0 < start < 100000000): # Any value larger than the server
                                         # user cnt and lower than 32bit
                                         # int max will do
-            await ctx.send(
-                messages.karma_lederboard_offser_error
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
             return
         await self.karma.leaderboard(ctx.message.channel, 'give', 'DESC', start)
         await self.check.botroom_check(ctx.message)
@@ -166,9 +154,7 @@ class Karma(commands.Cog):
         if (not 0 < start < 100000000): # Any value larger than the server
                                         # user cnt and lower than 32bit
                                         # int max will do
-            await ctx.send(
-                messages.karma_lederboard_offser_error
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
             return
         await self.karma.leaderboard(ctx.message.channel, 'give', 'ASC', start)
         await self.check.botroom_check(ctx.message)
@@ -179,9 +165,7 @@ class Karma(commands.Cog):
     @ishaboard.error
     async def leaderboard_error(self, ctx, error):
         if isinstance(error, commands.BadArgument):
-            await ctx.send(
-                messages.karma_lederboard_offser_error
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
 
 
 def setup(bot):

--- a/cogs/karma.py
+++ b/cogs/karma.py
@@ -2,7 +2,6 @@ import discord
 from discord.ext import commands
 
 import utils
-from utils import fill_message
 from config import messages, config
 from features import karma, reaction
 from repository import karma_repo
@@ -55,7 +54,7 @@ class Karma(commands.Cog):
                 target_member = await converter.convert(
                         ctx=ctx, argument=' '.join(args[1:]))
             except commands.errors.BadArgument:
-                await ctx.send(fill_message("member_not_found", user=ctx.author.id))
+                await ctx.send(utils.fill_message("member_not_found", user=ctx.author.id))
                 return
 
             await ctx.send(karma.karma_get(ctx.author, target_member))
@@ -111,9 +110,9 @@ class Karma(commands.Cog):
             if ctx.author.id == config.admin_id:
                 await karma.karma_give(ctx.message)
             else:
-                await ctx.send(fill_message("insufficient_rights", user=ctx.author.id))
+                await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
         else:
-            await ctx.send(fill_message("karma_invalid_command", user=ctx.author.id))
+            await ctx.send(utils.fill_message("karma_invalid_command", user=ctx.author.id))
 
     @commands.cooldown(rate=2, per=30.0, type=commands.BucketType.user)
     @commands.command()
@@ -121,7 +120,7 @@ class Karma(commands.Cog):
         if (not 0 < start < 100000000): # Any value larger than the server
                                         # user cnt and lower than 32bit
                                         # int max will do
-            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
+            await ctx.send(utils.fill_message("karma_lederboard_offser_error", user=ctx.author.id))
             return
         await self.karma.leaderboard(ctx.message.channel, 'get', 'DESC', start)
         await self.check.botroom_check(ctx.message)
@@ -132,7 +131,7 @@ class Karma(commands.Cog):
         if (not 0 < start < 100000000): # Any value larger than the server
                                         # user cnt and lower than 32bit
                                         # int max will do
-            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
+            await ctx.send(utils.fill_message("karma_lederboard_offser_error", user=ctx.author.id))
             return
         await self.karma.leaderboard(ctx.message.channel, 'get', 'ASC', start)
         await self.check.botroom_check(ctx.message)
@@ -143,7 +142,7 @@ class Karma(commands.Cog):
         if (not 0 < start < 100000000): # Any value larger than the server
                                         # user cnt and lower than 32bit
                                         # int max will do
-            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
+            await ctx.send(utils.fill_message("karma_lederboard_offser_error", user=ctx.author.id))
             return
         await self.karma.leaderboard(ctx.message.channel, 'give', 'DESC', start)
         await self.check.botroom_check(ctx.message)
@@ -154,7 +153,7 @@ class Karma(commands.Cog):
         if (not 0 < start < 100000000): # Any value larger than the server
                                         # user cnt and lower than 32bit
                                         # int max will do
-            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
+            await ctx.send(utils.fill_message("karma_lederboard_offser_error", user=ctx.author.id))
             return
         await self.karma.leaderboard(ctx.message.channel, 'give', 'ASC', start)
         await self.check.botroom_check(ctx.message)
@@ -165,7 +164,7 @@ class Karma(commands.Cog):
     @ishaboard.error
     async def leaderboard_error(self, ctx, error):
         if isinstance(error, commands.BadArgument):
-            await ctx.send(fill_message("karma_lederboard_offser_error", user=ctx.author.id))
+            await ctx.send(utils.fill_message("karma_lederboard_offser_error", user=ctx.author.id))
 
 
 def setup(bot):

--- a/cogs/karma.py
+++ b/cogs/karma.py
@@ -72,8 +72,7 @@ class Karma(commands.Cog):
 
         elif args[0] == "revote":
             if not await self.check.guild_check(ctx.message):
-                await ctx.send(
-                    "{}".format(messages.server_warning))
+                await ctx.send(messages.server_warning)
             else:
                 if ctx.message.channel.id == config.vote_room or \
                    ctx.author.id == config.admin_id:
@@ -83,15 +82,12 @@ class Karma(commands.Cog):
                     except discord.errors.Forbidden:
                         return
                 else:
-                    await ctx.send(
-                        messages.vote_room_only
-                        .format(room=discord.utils.get(ctx.guild.channels,
-                                                       id=config.vote_room)))
+                    await ctx.send(utils.fill_message("vote_room_only", 
+                                   room=discord.utils.get(ctx.guild.channels, id=config.vote_room)))
 
         elif args[0] == "vote":
             if not await self.check.guild_check(ctx.message):
-                await ctx.send(
-                    "{}".format(messages.server_warning))
+                await ctx.send(messages.server_warning)
             else:
                 if ctx.message.channel.id == config.vote_room or \
                    ctx.author.id == config.admin_id:
@@ -101,10 +97,8 @@ class Karma(commands.Cog):
                     except discord.errors.Forbidden:
                         return
                 else:
-                    await ctx.send(
-                        messages.vote_room_only
-                        .format(room=discord.utils.get(ctx.guild.channels,
-                                                       id=config.vote_room)))
+                    await ctx.send(utils.fill_message("vote_room_only", 
+                                   room=discord.utils.get(ctx.guild.channels, id=config.vote_room)))
 
         elif args[0] == "give":
             if ctx.author.id == config.admin_id:

--- a/cogs/karma.py
+++ b/cogs/karma.py
@@ -82,7 +82,7 @@ class Karma(commands.Cog):
                     except discord.errors.Forbidden:
                         return
                 else:
-                    await ctx.send(utils.fill_message("vote_room_only", 
+                    await ctx.send(utils.fill_message("vote_room_only",
                                    room=discord.utils.get(ctx.guild.channels, id=config.vote_room)))
 
         elif args[0] == "vote":

--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands
 
 import utils
+from utils import fill_message
 from config import config, messages
 
 config = config.Config
@@ -64,9 +65,7 @@ class Meme(commands.Cog):
     @hug.error
     async def hug_error(self, ctx, error):
         if isinstance(error, commands.BadArgument):
-            await ctx.send(
-                messages.member_not_found
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("member_not_found", user=ctx.author.id))
 
 
 def setup(bot):

--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -4,7 +4,6 @@ import discord
 from discord.ext import commands
 
 import utils
-from utils import fill_message
 from config import config, messages
 
 config = config.Config
@@ -65,7 +64,7 @@ class Meme(commands.Cog):
     @hug.error
     async def hug_error(self, ctx, error):
         if isinstance(error, commands.BadArgument):
-            await ctx.send(fill_message("member_not_found", user=ctx.author.id))
+            await ctx.send(utils.fill_message("member_not_found", user=ctx.author.id))
 
 
 def setup(bot):

--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -36,7 +36,7 @@ class Meme(commands.Cog):
 
     @commands.command()
     async def uhoh(self, ctx):
-        await ctx.send(messages.uhoh_counter.format(uhohs=uhoh_counter))
+        await ctx.send(utils.fill_message("uhoh_counter", uhohs=uhoh_counter))
 
     @commands.cooldown(rate=5, per=20.0, type=commands.BucketType.user)
     @commands.command(name='??')

--- a/cogs/random.py
+++ b/cogs/random.py
@@ -28,8 +28,7 @@ class Random(commands.Cog):
         """"Pick an option"""
         option = rng.pick_option(discord.utils.escape_mentions(' '.join(args)))
         if option:
-            await ctx.send("{} {}".format(option,
-                           utils.generate_mention(ctx.author.id)))
+            await ctx.send("{} {}".format(option, utils.generate_mention(ctx.author.id)))
         await self.check.botroom_check(ctx.message)
 
     @commands.cooldown(rate=5, per=20.0, type=commands.BucketType.user)

--- a/cogs/review.py
+++ b/cogs/review.py
@@ -5,6 +5,7 @@ from config import config, messages
 from features import review
 from repository import review_repo
 import utils
+from utils import fill_message
 
 config = config.Config
 messages = messages.Messages
@@ -68,8 +69,7 @@ class Review(commands.Cog):
                             review_repo.remove(tier)
                             await ctx.send(messages.review_remove_success)
                     else:
-                        await ctx.send(messages.insufficient_rights.format(
-                                user=utils.generate_mention(ctx.author.id)))
+                        await ctx.send(fill_message("insufficient_rights", user=ctx.author.id))
                 else:
                     if self.rev.remove(str(ctx.message.author.id), subject):
                         await ctx.send(messages.review_remove_success)

--- a/cogs/review.py
+++ b/cogs/review.py
@@ -32,8 +32,8 @@ class Review(commands.Cog):
             if subcommand == 'add':
                 for role in roles:
                     if role.name in config.reviews_forbidden_roles:
-                        await ctx.send(messages.review_add_denied.format(
-                                    user=ctx.message.author.mention))
+                        await ctx.send(utils.fill_message("review_add_denied",
+                                       user=ctx.message.author.mention))
                         return
                 if subject is None or tier is None:
                     await ctx.send(messages.review_add_format)
@@ -115,9 +115,7 @@ class Review(commands.Cog):
             else:
                 await ctx.send(messages.review_wrong_subject)
         else:
-            await ctx.send(
-                messages.insufficient_rights
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
 
 
 def setup(bot):

--- a/cogs/review.py
+++ b/cogs/review.py
@@ -53,7 +53,7 @@ class Review(commands.Cog):
                     args = None
                 try:
                     self.rev.add_review(author, subject, tier, anonym, args)
-                except:
+                except Exception:
                     await ctx.send(messages.review_wrong_subject)
                     return
                 await ctx.send(messages.review_added)

--- a/cogs/review.py
+++ b/cogs/review.py
@@ -5,7 +5,6 @@ from config import config, messages
 from features import review
 from repository import review_repo
 import utils
-from utils import fill_message
 
 config = config.Config
 messages = messages.Messages
@@ -69,7 +68,7 @@ class Review(commands.Cog):
                             review_repo.remove(tier)
                             await ctx.send(messages.review_remove_success)
                     else:
-                        await ctx.send(fill_message("insufficient_rights", user=ctx.author.id))
+                        await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
                 else:
                     if self.rev.remove(str(ctx.message.author.id), subject):
                         await ctx.send(messages.review_remove_success)

--- a/cogs/room_check.py
+++ b/cogs/room_check.py
@@ -1,4 +1,5 @@
 import utils
+from utils import fill_message
 from config import messages, config
 
 config = config.Config
@@ -13,9 +14,7 @@ class RoomCheck():
     async def botroom_check(self, message):
         room = await self.get_room(message)
         if room is not None and room.id not in config.allowed_channels:
-            await message.channel.send(messages.bot_room_redirect.format(
-                utils.generate_mention(message.author.id),
-                config.bot_room))
+            await message.channel.send(fill_message("bot_room_redirect", config.bot_room, user=message.author.id))
 
     async def get_room(self, message):
         guild = self.bot.get_guild(config.guild_id)

--- a/cogs/room_check.py
+++ b/cogs/room_check.py
@@ -1,8 +1,7 @@
 import utils
-from config import messages, config
+from config import config
 
 config = config.Config
-messages = messages.Messages
 
 
 class RoomCheck():
@@ -13,7 +12,8 @@ class RoomCheck():
     async def botroom_check(self, message):
         room = await self.get_room(message)
         if room is not None and room.id not in config.allowed_channels:
-            await message.channel.send(utils.fill_message("bot_room_redirect", config.bot_room, user=message.author.id))
+            await message.channel.send(utils.fill_message("bot_room_redirect",
+                                       config.bot_room, user=message.author.id))
 
     async def get_room(self, message):
         guild = self.bot.get_guild(config.guild_id)

--- a/cogs/room_check.py
+++ b/cogs/room_check.py
@@ -13,7 +13,7 @@ class RoomCheck():
         room = await self.get_room(message)
         if room is not None and room.id not in config.allowed_channels:
             await message.channel.send(utils.fill_message("bot_room_redirect",
-                                       config.bot_room, user=message.author.id))
+                                       user=message.author.id, bot_room=config.bot_room))
 
     async def get_room(self, message):
         guild = self.bot.get_guild(config.guild_id)

--- a/cogs/room_check.py
+++ b/cogs/room_check.py
@@ -1,5 +1,4 @@
 import utils
-from utils import fill_message
 from config import messages, config
 
 config = config.Config
@@ -14,7 +13,7 @@ class RoomCheck():
     async def botroom_check(self, message):
         room = await self.get_room(message)
         if room is not None and room.id not in config.allowed_channels:
-            await message.channel.send(fill_message("bot_room_redirect", config.bot_room, user=message.author.id))
+            await message.channel.send(utils.fill_message("bot_room_redirect", config.bot_room, user=message.author.id))
 
     async def get_room(self, message):
         guild = self.bot.get_guild(config.guild_id)

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -1,5 +1,5 @@
 from discord.ext import commands
-from config import config, messages
+from config import config
 from features import verification
 from repository import user_repo
 
@@ -7,7 +7,6 @@ from repository import user_repo
 user_r = user_repo.UserRepository()
 
 config = config.Config
-messages = messages.Messages
 
 
 class Verify(commands.Cog):

--- a/config/config.template.py
+++ b/config/config.template.py
@@ -112,7 +112,7 @@ class Config:
         "zzn", "jad", "jad", "izsl", "zpo", "zpoe", "zpd", "zpja", "asd",
         "zre", "zree"
     ]
-    reviews_forbidden_roles = ["MUNI","Host"]
+    reviews_forbidden_roles = ["MUNI", "Host"]
 
     # Arcas
     arcas_id = 140547421733126145

--- a/config/messages.py
+++ b/config/messages.py
@@ -29,8 +29,8 @@ class Messages:
     spamming = "{user} Nespamuj tolik <:sadcat:576171980118687754>"
     insufficient_rights = "{user}, na použití tohoto příkazu nemáš právo."
     vote_room_only = "Tohle funguje jen v {room}."
-    bot_room_redirect = "{} <:sadcat:576171980118687754> 👉 " \
-                        "<#{}>\n"
+    bot_room_redirect = "{user} <:sadcat:576171980118687754> 👉 " \
+                        "<#{bot_room}>\n"
     message_link_prefix = 'https://discordapp.com/channels/' \
                           + str(config.Config.guild_id) + '/'
 

--- a/config/messages.py
+++ b/config/messages.py
@@ -113,7 +113,7 @@ class Messages:
               "Implementovány featury podle obsahu: **8. Drop/Keep**"
 
     verify_already_verified = "{user} Už jsi byl verifikován " \
-                              "({toaster} pls)."
+                              "({admin} pls)."
     verify_send_format = "Očekávám jeden argument. " \
                          "Správný formát: " \
                          "`" + prefix + "getcode [FIT login, " \
@@ -125,7 +125,7 @@ class Messages:
                           "`" + prefix + "verify [login] [kód]`"
     verify_send_not_found = "{user} Login nenalezen " \
                             "nebo jsi už tímhle krokem " \
-                            "prošel ({toaster} pls)."
+                            "prošel ({admin} pls)."
     verify_verify_format = "Očekávám dva argumenty. " \
                            "Správný formát:\n" \
                            "`" + prefix + "verify [FIT login nebo " \
@@ -135,7 +135,7 @@ class Messages:
                            "xlogin00, nebo MUNI UCO]`"
     verify_verify_dumbshit = "{user} Kód, " \
                              "který ti přišel na mail. {emote}"
-    verify_verify_manual = "Čauec {user}, nechám {toaster}, " \
+    verify_verify_manual = "Čauec {user}, nechám {admin}, " \
                            "aby to udělal manuálně, " \
                            "jsi shady (Year: {year})"
     verify_verify_success = "{user} Gratuluji, byl jsi verifikován!"
@@ -146,7 +146,7 @@ class Messages:
 
     verify_verify_not_found = "{user} Login nenalezen nebo " \
                               "jsi už tímhle krokem prošel " \
-                              "({toaster} pls)."
+                              "({admin} pls)."
     verify_verify_wrong_code = "{user} Špatný kód."
 
     vote_format = "Použití vote:\n`" + prefix + "vote [datum] [čas] [otázka]\n[emoji]" \

--- a/config/messages.py
+++ b/config/messages.py
@@ -127,10 +127,10 @@ class Messages:
                             "nebo jsi už tímhle krokem " \
                             "prošel ({toaster} pls)."
     verify_verify_format = "Očekávám dva argumenty. " \
-                           "Správný formát: " \
+                           "Správný formát:\n" \
                            "`" + prefix + "verify [FIT login nebo " \
                            "MUNI UCO] [kód]`\n" \
-                           "Pro získání kódu použij `" +\
+                           "Pro získání kódu použij\n`" +\
                            prefix + "getcode [FIT login, ve tvaru " \
                            "xlogin00, nebo MUNI UCO]`"
     verify_verify_dumbshit = "{user} Kód, " \

--- a/features/acl.py
+++ b/features/acl.py
@@ -1,4 +1,5 @@
 import utils
+from utils import fill_message
 from config import messages
 from features.base_feature import BaseFeature
 from repository.acl_repo import AclRepository
@@ -23,9 +24,7 @@ class Acl(BaseFeature):
 
     async def handle_add(self, ctx, args):
         if not len(args):
-            await ctx.send(
-                messages.acl_help
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("acl_help", user=ctx.author.id))
             return
 
         if args[0] == "group" and 2 <= len(args) <= 3:
@@ -37,16 +36,12 @@ class Acl(BaseFeature):
         elif args[0] == "user" and len(args) == 4:
             await self.add_user(ctx, args[1:])
         else:
-            await ctx.send(
-                messages.acl_help
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("acl_help", user=ctx.author.id))
             return
 
     async def handle_edit(self, ctx, args):
         if not len(args):
-            await ctx.send(
-                messages.acl_help
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("acl_help", user=ctx.author.id))
             return
 
         if args[0] == "group" and 3 <= len(args) <= 4:
@@ -58,16 +53,12 @@ class Acl(BaseFeature):
         elif args[0] == "user" and len(args) == 4:
             await self.edit_user(ctx, args[1:])
         else:
-            await ctx.send(
-                messages.acl_help
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("acl_help", user=ctx.author.id))
             return
 
     async def handle_del(self, ctx, args):
         if not len(args):
-            await ctx.send(
-                messages.acl_help
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("acl_help", user=ctx.author.id))
             return
 
         if args[0] == "group" and len(args) == 2:
@@ -79,16 +70,12 @@ class Acl(BaseFeature):
         elif args[0] == "user" and len(args) == 2:
             await self.del_user(ctx, args[1])
         else:
-            await ctx.send(
-                messages.acl_help
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("acl_help", user=ctx.author.id))
             return
 
     async def handle_list(self, ctx, args):
         if not len(args) or len(args) > 2:
-            await ctx.send(
-                messages.acl_help
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("acl_help", user=ctx.author.id))
             return
 
         if args[0] == "group":
@@ -100,9 +87,7 @@ class Acl(BaseFeature):
         elif args[0] == "user":
             await self.list_user(ctx, args[1:])
         else:
-            await ctx.send(
-                messages.acl_help
-                .format(user=utils.generate_mention(ctx.author.id)))
+            await ctx.send(fill_message("acl_help", user=ctx.author.id))
             return
 
     async def add_group(self, ctx, args):

--- a/features/acl.py
+++ b/features/acl.py
@@ -1,5 +1,4 @@
 import utils
-from utils import fill_message
 from config import messages
 from features.base_feature import BaseFeature
 from repository.acl_repo import AclRepository
@@ -24,7 +23,7 @@ class Acl(BaseFeature):
 
     async def handle_add(self, ctx, args):
         if not len(args):
-            await ctx.send(fill_message("acl_help", user=ctx.author.id))
+            await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
             return
 
         if args[0] == "group" and 2 <= len(args) <= 3:
@@ -36,12 +35,12 @@ class Acl(BaseFeature):
         elif args[0] == "user" and len(args) == 4:
             await self.add_user(ctx, args[1:])
         else:
-            await ctx.send(fill_message("acl_help", user=ctx.author.id))
+            await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
             return
 
     async def handle_edit(self, ctx, args):
         if not len(args):
-            await ctx.send(fill_message("acl_help", user=ctx.author.id))
+            await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
             return
 
         if args[0] == "group" and 3 <= len(args) <= 4:
@@ -53,12 +52,12 @@ class Acl(BaseFeature):
         elif args[0] == "user" and len(args) == 4:
             await self.edit_user(ctx, args[1:])
         else:
-            await ctx.send(fill_message("acl_help", user=ctx.author.id))
+            await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
             return
 
     async def handle_del(self, ctx, args):
         if not len(args):
-            await ctx.send(fill_message("acl_help", user=ctx.author.id))
+            await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
             return
 
         if args[0] == "group" and len(args) == 2:
@@ -70,12 +69,12 @@ class Acl(BaseFeature):
         elif args[0] == "user" and len(args) == 2:
             await self.del_user(ctx, args[1])
         else:
-            await ctx.send(fill_message("acl_help", user=ctx.author.id))
+            await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
             return
 
     async def handle_list(self, ctx, args):
         if not len(args) or len(args) > 2:
-            await ctx.send(fill_message("acl_help", user=ctx.author.id))
+            await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
             return
 
         if args[0] == "group":
@@ -87,7 +86,7 @@ class Acl(BaseFeature):
         elif args[0] == "user":
             await self.list_user(ctx, args[1:])
         else:
-            await ctx.send(fill_message("acl_help", user=ctx.author.id))
+            await ctx.send(utils.fill_message("acl_help", user=ctx.author.id))
             return
 
     async def add_group(self, ctx, args):

--- a/features/karma.py
+++ b/features/karma.py
@@ -39,13 +39,10 @@ class Karma(BaseFeature):
 
     async def emoji_process_vote(self, channel, emoji):
         delay = cfg.vote_minutes * 60
-        message = await channel.send(
-            "{}\n{}".format(msg.karma_vote_message
-                            .format(emote=str(emoji)),
-                            msg.karma_vote_info
-                            .format(delay=str(delay // 60),
-                                    minimum=str(cfg.vote_minimum))))
-
+        message = utils.fill_message("karma_vote_message", emote=str(emoji))
+        message += '\n'
+        message += utils.fill_message("karma_vote_info", delay=str(delay//60), minimum=str(cfg.vote_minimum))
+        message = await channel.send(message)
         await message.add_reaction("✅")
         await message.add_reaction("❌")
         await message.add_reaction("0⃣")
@@ -102,17 +99,13 @@ class Karma(BaseFeature):
 
         if vote_value is None:
             self.repo.remove_emoji(emoji)
-            await message.channel.send(
-                msg.karma_vote_notpassed
-                .format(emote=str(emoji),
-                        minimum=str(cfg.vote_minimum)))
+            await message.channel.send(utils.fill_message("karma_vote_notpassed", 
+                                       emote=str(emoji), minimum=str(cfg.vote_minimum)))
 
         else:
             self.repo.set_emoji_value(emoji, vote_value)
-            await message.channel.send(
-                msg.karma_vote_result
-                .format(emote=str(emoji),
-                        result=str(vote_value)))
+            await message.channel.send(utils.fill_message("karma_vote_result",
+                                       emote=str(emoji), result=str(vote_value)))
 
     async def emoji_revote_value(self, message):
         content = message.content.split()
@@ -136,14 +129,11 @@ class Karma(BaseFeature):
 
         if vote_value is not None:
             self.repo.set_emoji_value(emoji, vote_value)
-            await message.channel.send(
-                msg.karma_vote_result
-                .format(emote=str(emoji), result=str(vote_value)))
+            await message.channel.send(utils.fill_message("karma_vote_result",
+                                       emote=str(emoji), result=str(vote_value)))
         else:
-            await message.channel.send(
-                msg.karma_vote_notpassed
-                .format(emote=str(emoji),
-                        minimum=str(cfg.vote_minimum)))
+            await message.channel.send(utils.fill_message("karma_vote_notpassed",
+                                       emote=str(emoji), minimum=str(cfg.vote_minimum)))
 
     async def emoji_get_value(self, message):
         content = message.content.split()
@@ -165,13 +155,9 @@ class Karma(BaseFeature):
         val = self.repo.emoji_value_raw(emoji)
 
         if val is not None:
-            await message.channel.send(
-                msg.karma_get
-                .format(emote=str(emoji), value=str(val)))
+            await message.channel.send(utils.fill_message("karma_get", emote=str(emoji), value=str(val)))
         else:
-            await message.channel.send(
-                msg.karma_get_emote_not_voted
-                .format(emote=str(emoji)))
+            await message.channel.send(utils.fill_message("karma_get_emote_not_voted", emote=str(emoji)))
 
     async def __make_emoji_list(self, guild, emojis):
         message = []
@@ -249,10 +235,8 @@ class Karma(BaseFeature):
             try:
                 number = int(input_string[2])
             except ValueError:
-                await message.channel.send(
-                    msg.karma_give_format_number.format(
-                        input=input_string[2])
-                )
+                await message.channel.send(utils.fill_message("karma_give_format_number",
+                                                              input=input_string[2]))
                 return
             for member in message.mentions:
                 self.repo.update_karma(member, message.author, number)
@@ -267,15 +251,16 @@ class Karma(BaseFeature):
         if target is None:
             target = author
         k = self.repo.get_karma(target.id)
-        return msg.karma.format(user=utils.generate_mention(
-                                author.id),
-                                karma=k.karma.value,
-                                order=k.karma.position,
-                                target=target.display_name,
-                                karma_pos=k.positive.value,
-                                karma_pos_order=k.positive.position,
-                                karma_neg=k.negative.value,
-                                karma_neg_order=k.negative.position)
+        return utils.fill_message("karma",
+            user=author.id,
+            karma=k.karma.value,
+            order=k.karma.position,
+            target=target.display_name,
+            karma_pos=k.positive.value,
+            karma_pos_order=k.positive.position,
+            karma_neg=k.negative.value,
+            karma_neg_order=k.negative.position
+        )
 
     async def leaderboard(self, channel, action, order, start=1):
         output = "> "

--- a/features/karma.py
+++ b/features/karma.py
@@ -182,10 +182,8 @@ class Karma(BaseFeature):
                 # and as that will probably fail anyway, it'll jump to
                 # the discord.NotFound handler which will add it to
                 # the error message
-                emoji = next(
-                        (x for x in guild.emojis if x.id == int(emoji_id)),
-                        None
-                        )
+                emoji = next((x for x in guild.emojis if x.id == int(emoji_id)), None)
+
                 if emoji is None:
                     emoji = await guild.fetch_emoji(int(emoji_id))
 
@@ -213,8 +211,7 @@ class Karma(BaseFeature):
         for value in ['1', '-1']:
             emojis, is_error = await self.__make_emoji_list(
                     channel.guild,
-                    self.repo.get_ids_of_emojis_valued(value)
-                    )
+                    self.repo.get_ids_of_emojis_valued(value))
             error |= is_error
             try:
                 await channel.send("Hodnota " + value + ":")

--- a/features/karma.py
+++ b/features/karma.py
@@ -251,7 +251,8 @@ class Karma(BaseFeature):
         if target is None:
             target = author
         k = self.repo.get_karma(target.id)
-        return utils.fill_message("karma",
+        return utils.fill_message(
+            "karma",
             user=author.id,
             karma=k.karma.value,
             order=k.karma.position,

--- a/features/reaction.py
+++ b/features/reaction.py
@@ -4,6 +4,7 @@ from discord.ext.commands import Bot
 import re
 
 import utils
+from utils import fill_message
 from config.config import Config
 from config.messages import Messages
 from features.base_feature import BaseFeature
@@ -62,12 +63,7 @@ class Reaction(BaseFeature):
                 input_string = input_string[input_string.index('\n') + 1:]
             input_string = input_string.rstrip().split('\n')
         except ValueError:
-            await message.channel.send(
-                Messages.role_format
-                .format(user=utils.generate_mention(
-                    message.author.id)
-                )
-            )
+            await message.channel.send(fill_message("role_format", user=message.author.id))
             return None
         output = []
         for line in input_string:
@@ -76,13 +72,8 @@ class Reaction(BaseFeature):
                 out = [out[1], out[0]]
                 output.append(out)
             except:
-                await message.channel.send(
-                    Messages.role_invalid_line
-                    .format(user=utils.generate_mention(
-                        message.author.id),
-                        line=line
-                    )
-                )
+                await message.channel.send(fill_message("role_invalid_line",
+                                           user=message.author.id, line=line))
         for line in output:
             if "<#" in line[0]:
                 line[0] = line[0].replace("<#", "")
@@ -90,13 +81,8 @@ class Reaction(BaseFeature):
                 try:
                     line[0] = int(line[0])
                 except:
-                    await message.channel.send(
-                        Messages.role_invalid_line
-                        .format(user=utils.generate_mention(
-                            message.author.id),
-                            line=line[0]
-                        )
-                    )
+                    await message.channel.send(fill_message("role_invalid_line",
+                                            user=message.author.id, line=line[0]))
         return output
 
     # Adds reactions to message
@@ -116,20 +102,14 @@ class Reaction(BaseFeature):
                     discord.utils.get(guild.channels,
                                       name=line[0][1:].lower()) is None
             if not_role and not_channel:
-                await message.channel.send(
-                    Messages.role_not_role
-                    .format(user=utils.generate_mention(
-                        message.author.id),
-                        not_role=line[0]))
+                await message.channel.send(fill_message("role_not_role",
+                                        user=message.author.id, not_role=line[0]))
             else:
                 try:
                     await message.add_reaction(line[1])
                 except discord.errors.HTTPException:
-                    await message.channel.send(
-                        Messages.role_invalid_emote
-                        .format(user=utils.generate_mention(
-                            message.author.id),
-                            not_emote=line[1], role=line[0]))
+                    await message.channel.send(fill_message("role_invalid_emote",
+                                            user=message.author.id, not_role=line[1], role=line[0]))
 
     async def add(self, payload):
         channel = self.bot.get_channel(payload.channel_id)
@@ -353,9 +333,8 @@ class Reaction(BaseFeature):
                 await member.add_roles(role)
             else:
                 bot_room = self.bot.get_channel(Config.bot_room)
-                await bot_room.send(Messages.role_add_denied
-                                    .format(user=utils.generate_mention(
-                                       member.id), role=role.name))
+                await bot_room.send(fill_message("role_add_denied",
+                                        user=member.id, role=role.name))
         else:
             try:
                 channel = discord.utils.get(guild.channels, id=int(target))
@@ -373,9 +352,8 @@ class Reaction(BaseFeature):
                 await channel.set_permissions(member, read_messages=True)
             else:
                 bot_room = self.bot.get_channel(Config.bot_room)
-                await bot_room.send(Messages.role_add_denied
-                                    .format(user=utils.generate_mention(
-                                        member.id), role=channel.name))
+                await bot_room.send(fill_message("role_add_denied",
+                                        user=member.id, role=channel.name))
 
     # Removes a role for user based on reaction
     async def remove_role_on_reaction(self, target, member, channel, guild):
@@ -388,13 +366,8 @@ class Reaction(BaseFeature):
                     await member.remove_roles(role)
                 else:
                     bot_room = self.bot.get_channel(Config.bot_room)
-                    await bot_room.send(
-                        Messages.role_remove_denied
-                        .format(user=utils.generate_mention(
-                            member.id),
-                            role=role.name
-                        )
-                    )
+                    await bot_room.send(fill_message("role_remove_denied",
+                                            user=member.id, role=role.name))
         else:
             try:
                 channel = discord.utils.get(guild.channels, id=int(target))
@@ -412,9 +385,8 @@ class Reaction(BaseFeature):
                                               send_messages=None)
             else:
                 bot_room = self.bot.get_channel(Config.bot_room)
-                await bot_room.send(Messages.role_remove_denied
-                                    .format(user=utils.generate_mention(
-                                        member.id), role=channel.name))
+                await bot_room.send(fill_message("role_remove_denied",
+                                        user=member.id, role=channel.name))
 
     def pagination_next(self, emoji, page, max_page):
         if emoji in ["▶", "🔽"]:

--- a/features/reaction.py
+++ b/features/reaction.py
@@ -4,7 +4,6 @@ from discord.ext.commands import Bot
 import re
 
 import utils
-from utils import fill_message
 from config.config import Config
 from config.messages import Messages
 from features.base_feature import BaseFeature
@@ -63,7 +62,7 @@ class Reaction(BaseFeature):
                 input_string = input_string[input_string.index('\n') + 1:]
             input_string = input_string.rstrip().split('\n')
         except ValueError:
-            await message.channel.send(fill_message("role_format", user=message.author.id))
+            await message.channel.send(utils.fill_message("role_format", user=message.author.id))
             return None
         output = []
         for line in input_string:
@@ -72,7 +71,7 @@ class Reaction(BaseFeature):
                 out = [out[1], out[0]]
                 output.append(out)
             except:
-                await message.channel.send(fill_message("role_invalid_line",
+                await message.channel.send(utils.fill_message("role_invalid_line",
                                            user=message.author.id, line=line))
         for line in output:
             if "<#" in line[0]:
@@ -81,7 +80,7 @@ class Reaction(BaseFeature):
                 try:
                     line[0] = int(line[0])
                 except:
-                    await message.channel.send(fill_message("role_invalid_line",
+                    await message.channel.send(utils.fill_message("role_invalid_line",
                                             user=message.author.id, line=line[0]))
         return output
 
@@ -102,13 +101,13 @@ class Reaction(BaseFeature):
                     discord.utils.get(guild.channels,
                                       name=line[0][1:].lower()) is None
             if not_role and not_channel:
-                await message.channel.send(fill_message("role_not_role",
+                await message.channel.send(utils.fill_message("role_not_role",
                                         user=message.author.id, not_role=line[0]))
             else:
                 try:
                     await message.add_reaction(line[1])
                 except discord.errors.HTTPException:
-                    await message.channel.send(fill_message("role_invalid_emote",
+                    await message.channel.send(utils.fill_message("role_invalid_emote",
                                             user=message.author.id, not_role=line[1], role=line[0]))
 
     async def add(self, payload):
@@ -333,7 +332,7 @@ class Reaction(BaseFeature):
                 await member.add_roles(role)
             else:
                 bot_room = self.bot.get_channel(Config.bot_room)
-                await bot_room.send(fill_message("role_add_denied",
+                await bot_room.send(utils.fill_message("role_add_denied",
                                         user=member.id, role=role.name))
         else:
             try:
@@ -352,7 +351,7 @@ class Reaction(BaseFeature):
                 await channel.set_permissions(member, read_messages=True)
             else:
                 bot_room = self.bot.get_channel(Config.bot_room)
-                await bot_room.send(fill_message("role_add_denied",
+                await bot_room.send(utils.fill_message("role_add_denied",
                                         user=member.id, role=channel.name))
 
     # Removes a role for user based on reaction
@@ -366,7 +365,7 @@ class Reaction(BaseFeature):
                     await member.remove_roles(role)
                 else:
                     bot_room = self.bot.get_channel(Config.bot_room)
-                    await bot_room.send(fill_message("role_remove_denied",
+                    await bot_room.send(utils.fill_message("role_remove_denied",
                                             user=member.id, role=role.name))
         else:
             try:
@@ -385,7 +384,7 @@ class Reaction(BaseFeature):
                                               send_messages=None)
             else:
                 bot_room = self.bot.get_channel(Config.bot_room)
-                await bot_room.send(fill_message("role_remove_denied",
+                await bot_room.send(utils.fill_message("role_remove_denied",
                                         user=member.id, role=channel.name))
 
     def pagination_next(self, emoji, page, max_page):

--- a/features/reaction.py
+++ b/features/reaction.py
@@ -70,7 +70,7 @@ class Reaction(BaseFeature):
                 out = line.split(" - ", 1)[0].split()
                 out = [out[1], out[0]]
                 output.append(out)
-            except:
+            except Exception:
                 await message.channel.send(utils.fill_message("role_invalid_line",
                                            user=message.author.id, line=line))
         for line in output:
@@ -79,7 +79,7 @@ class Reaction(BaseFeature):
                 line[0] = line[0].replace(">", "")
                 try:
                     line[0] = int(line[0])
-                except:
+                except Exception:
                     await message.channel.send(utils.fill_message("role_invalid_line",
                                                user=message.author.id, line=line[0]))
         return output
@@ -171,7 +171,7 @@ class Reaction(BaseFeature):
                     await message.edit(embed=embed)
             try:
                 await message.remove_reaction(emoji, member)
-            except:
+            except Exception:
                 pass
         elif message.embeds and\
                 message.embeds[0].title is not discord.Embed.Empty and\
@@ -234,7 +234,7 @@ class Reaction(BaseFeature):
                         await message.edit(embed=embed)
             try:
                 await message.remove_reaction(emoji, member)
-            except:
+            except Exception:
                 pass
         elif member.id != message.author.id and\
                 guild.id == Config.guild_id and\

--- a/features/reaction.py
+++ b/features/reaction.py
@@ -81,7 +81,7 @@ class Reaction(BaseFeature):
                     line[0] = int(line[0])
                 except:
                     await message.channel.send(utils.fill_message("role_invalid_line",
-                                            user=message.author.id, line=line[0]))
+                                               user=message.author.id, line=line[0]))
         return output
 
     # Adds reactions to message
@@ -102,13 +102,13 @@ class Reaction(BaseFeature):
                                       name=line[0][1:].lower()) is None
             if not_role and not_channel:
                 await message.channel.send(utils.fill_message("role_not_role",
-                                        user=message.author.id, not_role=line[0]))
+                                           user=message.author.id, not_role=line[0]))
             else:
                 try:
                     await message.add_reaction(line[1])
                 except discord.errors.HTTPException:
                     await message.channel.send(utils.fill_message("role_invalid_emote",
-                                            user=message.author.id, not_role=line[1], role=line[0]))
+                                               user=message.author.id, not_role=line[1], role=line[0]))
 
     async def add(self, payload):
         channel = self.bot.get_channel(payload.channel_id)
@@ -333,7 +333,7 @@ class Reaction(BaseFeature):
             else:
                 bot_room = self.bot.get_channel(Config.bot_room)
                 await bot_room.send(utils.fill_message("role_add_denied",
-                                        user=member.id, role=role.name))
+                                    user=member.id, role=role.name))
         else:
             try:
                 channel = discord.utils.get(guild.channels, id=int(target))
@@ -352,7 +352,7 @@ class Reaction(BaseFeature):
             else:
                 bot_room = self.bot.get_channel(Config.bot_room)
                 await bot_room.send(utils.fill_message("role_add_denied",
-                                        user=member.id, role=channel.name))
+                                    user=member.id, role=channel.name))
 
     # Removes a role for user based on reaction
     async def remove_role_on_reaction(self, target, member, channel, guild):
@@ -366,7 +366,7 @@ class Reaction(BaseFeature):
                 else:
                     bot_room = self.bot.get_channel(Config.bot_room)
                     await bot_room.send(utils.fill_message("role_remove_denied",
-                                            user=member.id, role=role.name))
+                                        user=member.id, role=role.name))
         else:
             try:
                 channel = discord.utils.get(guild.channels, id=int(target))
@@ -385,7 +385,7 @@ class Reaction(BaseFeature):
             else:
                 bot_room = self.bot.get_channel(Config.bot_room)
                 await bot_room.send(utils.fill_message("role_remove_denied",
-                                        user=member.id, role=channel.name))
+                                    user=member.id, role=channel.name))
 
     def pagination_next(self, emoji, page, max_page):
         if emoji in ["▶", "🔽"]:

--- a/features/verification.py
+++ b/features/verification.py
@@ -8,6 +8,7 @@ from discord import Member
 from discord.ext.commands import Bot
 
 import utils
+from utils import fill_message
 from config.config import Config
 from config.messages import Messages
 from features.base_feature import BaseFeature
@@ -55,11 +56,8 @@ class Verification(BaseFeature):
         # Save the newly generated code into the database
         self.repo.save_sent_code(login, code)
 
-        await message.channel.send(
-            Messages.verify_send_success
-            .format(user=utils.generate_mention(
-                message.author.id),
-                    mail=mail_postfix))
+        await message.channel.send(fill_message("verify_send_success", 
+                                    user=message.author.id, mail=mail_postfix))
 
     async def send_code(self, message):
         if len(str(message.content).split(" ")) != 2:
@@ -75,13 +73,8 @@ class Verification(BaseFeature):
             if login == "xlogin00":
                 guild = self.bot.get_guild(Config.guild_id)
                 fp = await guild.fetch_emoji(585915845146968093)
-                await message.channel.send(
-                    Messages.verify_send_dumbshit
-                    .format(emote=str(fp),
-                            user=utils.generate_mention(
-                        message.author.id)
-                    )
-                )
+                await message.channel.send(fill_message("verify_send_dumbshit", 
+                                           user=message.author.id, emote=str(fp)))
                 return
             if login[0] == 'x':
                 # VUT
@@ -90,12 +83,9 @@ class Verification(BaseFeature):
                     await self.gen_code_and_send_mail(message, login,
                                                       "@stud.fit.vutbr.cz")
                 else:
-                    await message.channel.send(
-                        Messages.verify_send_not_found
-                        .format(user=utils.generate_mention(
-                            message.author.id),
-                            toaster=utils.generate_mention(
-                            Config.admin_id)))
+                    await message.channel.send(fill_message("verify_send_not_found",
+                                   user=message.author.id, toaster=Config.admin_id))
+
                     embed = discord.Embed(title="Neuspesny pokus o verify",
                                           color=0xeee657)
                     embed.add_field(name="User", value=utils.generate_mention(message.author.id))
@@ -108,12 +98,9 @@ class Verification(BaseFeature):
                 try:
                     int(login)
                 except ValueError:
-                    await message.channel.send(
-                        Messages.verify_send_not_found
-                        .format(user=utils.generate_mention(
-                            message.author.id),
-                            toaster=utils.generate_mention(
-                            Config.admin_id)))
+                    await message.channel.send(fill_message("verify_send_not_found",
+                                   user=message.author.id, toaster=Config.admin_id))
+
                     embed = discord.Embed(title="Neuspesny pokus o verify",
                                           color=0xeee657)
                     embed.add_field(name="User", value=utils.generate_mention(message.author.id))
@@ -133,12 +120,9 @@ class Verification(BaseFeature):
                     await self.gen_code_and_send_mail(message, login,
                                                       "@mail.muni.cz")
                 else:
-                    await message.channel.send(
-                        Messages.verify_send_not_found
-                        .format(user=utils.generate_mention(
-                            message.author.id),
-                            toaster=utils.generate_mention(
-                            Config.admin_id)))
+                    await message.channel.send(fill_message("verify_send_not_found",
+                                   user=message.author.id, toaster=Config.admin_id))
+
                     embed = discord.Embed(title="Neuspesny pokus o verify",
                                           color=0xeee657)
                     embed.add_field(name="User", value=utils.generate_mention(message.author.id))
@@ -147,14 +131,8 @@ class Verification(BaseFeature):
                     channel = self.bot.get_channel(Config.log_channel)
                     await channel.send(embed=embed)
         else:
-            await message.channel.send(
-                Messages.verify_already_verified
-                .format(user=utils.generate_mention(
-                    message.author.id),
-                    toaster=utils.generate_mention(
-                    Config.admin_id)
-                )
-            )
+            await message.channel.send(fill_message("verify_already_verified",
+                            user=message.author.id, toaster=Config.admin_id))
         try:
             await message.delete()
         except discord.errors.Forbidden:
@@ -216,25 +194,15 @@ class Verification(BaseFeature):
             if login == "xlogin00":
                 guild = self.bot.get_guild(Config.guild_id)
                 fp = await guild.fetch_emoji(585915845146968093)
-                await message.channel.send(
-                    Messages.verify_send_dumbshit
-                    .format(emote=str(fp),
-                            user=utils.generate_mention(
-                        message.author.id)
-                    )
-                )
+                await message.channel.send(fill_message("verify_send_dumbshit",
+                                user=message.author.id, emote=str(fp)))
                 return
             # Same here
             if code == "kód" or code == "[kód]":
                 guild = self.bot.get_guild(Config.guild_id)
                 fp = await guild.fetch_emoji(585915845146968093)
-                await message.channel.send(
-                    Messages.verify_verify_dumbshit
-                    .format(emote=str(fp),
-                            user=utils.generate_mention(
-                        message.author.id)
-                    )
-                )
+                await message.channel.send(fill_message("verify_verify_dumbshit",
+                                user=message.author.id, emote=str(fp)))
                 return
 
             new_user = self.repo.get_user(login)
@@ -242,10 +210,8 @@ class Verification(BaseFeature):
             if new_user is not None:
                 # Check the code
                 if code != new_user.code:
-                    await message.channel.send(
-                            Messages.verify_verify_wrong_code
-                            .format(user=utils.generate_mention(
-                                    message.author.id)))
+                    await message.channel.send(fill_message("verify_verify_wrong_code",
+                                    user=message.author.id))
                     embed = discord.Embed(title="Neuspesny pokus o verify(kod)",
                                           color=0xeee657)
                     embed.add_field(name="User", value=utils.generate_mention(message.author.id))
@@ -259,13 +225,12 @@ class Verification(BaseFeature):
                 year = self.transform_year(new_user.year)
 
                 if year is None:
-                    await message.channel.send(
-                        Messages.verify_verify_manual
-                        .format(user=utils.generate_mention(
-                            message.author.id),
-                            toaster=utils.generate_mention(
-                            Config.admin_id),
-                            year=str(new_user.year)))
+                    await message.channel.send(fill_message("verify_verify_manual",
+                                                            user=message.author.id,
+                                                            toaster=Config.admin_id,
+                                                            year=str(new_user.year))
+                    )
+
                     embed = discord.Embed(title="Neuspesny pokus o verify(manual)",
                                           color=0xeee657)
                     embed.add_field(name="User", value=utils.generate_mention(message.author.id))
@@ -296,29 +261,18 @@ class Verification(BaseFeature):
 
                 self.repo.save_verified(login, message.author.id)
 
-                await member.send(
-                    Messages.verify_verify_success
-                    .format(user=utils.generate_mention(
-                        message.author.id)
-                    )
-                )
-                await member.send(
-                    Messages.verify_post_verify_info
-                )
+                await message.channel.send(fill_message("verify_verify_success",
+                                user=message.author.id))
+
+                await member.send(Messages.verify_post_verify_info)
+
                 if message.channel.type is not discord.ChannelType.private:
-                    await message.channel.send(
-                        Messages.verify_verify_success
-                        .format(user=utils.generate_mention(
-                            message.author.id)
-                        )
-                    )
+                    await message.channel.send(fill_message("verify_verify_success",
+                                    user=message.author.id))
             else:
-                await message.channel.send(
-                    Messages.verify_verify_not_found
-                    .format(user=utils.generate_mention(
-                        message.author.id),
-                        toaster=utils.generate_mention(
-                        Config.admin_id)))
+                await message.channel.send(fill_message("verify_verify_not_found",
+                                user=message.author.id, toaster=Config.admin_id))
+
                 embed = discord.Embed(title="Neuspesny pokus o verify",
                                       color=0xeee657)
                 embed.add_field(name="User", value=utils.generate_mention(message.author.id))
@@ -327,14 +281,9 @@ class Verification(BaseFeature):
                 channel = self.bot.get_channel(Config.log_channel)
                 await channel.send(embed=embed)
         else:
-            await message.channel.send(
-                Messages.verify_already_verified
-                .format(user=utils.generate_mention(
-                    message.author.id),
-                    toaster=utils.generate_mention(
-                    Config.admin_id)
-                )
-            )
+            await message.channel.send(fill_message("verify_verify_already_verified",
+                            user=message.author.id, toaster=Config.admin_id))
+
         try:
             await message.delete()
         except discord.errors.Forbidden:

--- a/features/verification.py
+++ b/features/verification.py
@@ -8,7 +8,6 @@ from discord import Member
 from discord.ext.commands import Bot
 
 import utils
-from utils import fill_message
 from config.config import Config
 from config.messages import Messages
 from features.base_feature import BaseFeature
@@ -56,7 +55,7 @@ class Verification(BaseFeature):
         # Save the newly generated code into the database
         self.repo.save_sent_code(login, code)
 
-        await message.channel.send(fill_message("verify_send_success", 
+        await message.channel.send(utils.fill_message("verify_send_success", 
                                     user=message.author.id, mail=mail_postfix))
 
     async def send_code(self, message):
@@ -73,7 +72,7 @@ class Verification(BaseFeature):
             if login == "xlogin00":
                 guild = self.bot.get_guild(Config.guild_id)
                 fp = await guild.fetch_emoji(585915845146968093)
-                await message.channel.send(fill_message("verify_send_dumbshit", 
+                await message.channel.send(utils.fill_message("verify_send_dumbshit", 
                                            user=message.author.id, emote=str(fp)))
                 return
             if login[0] == 'x':
@@ -83,8 +82,8 @@ class Verification(BaseFeature):
                     await self.gen_code_and_send_mail(message, login,
                                                       "@stud.fit.vutbr.cz")
                 else:
-                    await message.channel.send(fill_message("verify_send_not_found",
-                                   user=message.author.id, toaster=Config.admin_id))
+                    await message.channel.send(utils.fill_message("verify_send_not_found",
+                                   user=message.author.id, admin=Config.admin_id))
 
                     embed = discord.Embed(title="Neuspesny pokus o verify",
                                           color=0xeee657)
@@ -98,8 +97,8 @@ class Verification(BaseFeature):
                 try:
                     int(login)
                 except ValueError:
-                    await message.channel.send(fill_message("verify_send_not_found",
-                                   user=message.author.id, toaster=Config.admin_id))
+                    await message.channel.send(utils.fill_message("verify_send_not_found",
+                                   user=message.author.id, admin=Config.admin_id))
 
                     embed = discord.Embed(title="Neuspesny pokus o verify",
                                           color=0xeee657)
@@ -120,8 +119,8 @@ class Verification(BaseFeature):
                     await self.gen_code_and_send_mail(message, login,
                                                       "@mail.muni.cz")
                 else:
-                    await message.channel.send(fill_message("verify_send_not_found",
-                                   user=message.author.id, toaster=Config.admin_id))
+                    await message.channel.send(utils.fill_message("verify_send_not_found",
+                                   user=message.author.id, admin=Config.admin_id))
 
                     embed = discord.Embed(title="Neuspesny pokus o verify",
                                           color=0xeee657)
@@ -131,8 +130,8 @@ class Verification(BaseFeature):
                     channel = self.bot.get_channel(Config.log_channel)
                     await channel.send(embed=embed)
         else:
-            await message.channel.send(fill_message("verify_already_verified",
-                            user=message.author.id, toaster=Config.admin_id))
+            await message.channel.send(utils.fill_message("verify_already_verified",
+                            user=message.author.id, admin=Config.admin_id))
         try:
             await message.delete()
         except discord.errors.Forbidden:
@@ -194,14 +193,14 @@ class Verification(BaseFeature):
             if login == "xlogin00":
                 guild = self.bot.get_guild(Config.guild_id)
                 fp = await guild.fetch_emoji(585915845146968093)
-                await message.channel.send(fill_message("verify_send_dumbshit",
+                await message.channel.send(utils.fill_message("verify_send_dumbshit",
                                 user=message.author.id, emote=str(fp)))
                 return
             # Same here
             if code == "kód" or code == "[kód]":
                 guild = self.bot.get_guild(Config.guild_id)
                 fp = await guild.fetch_emoji(585915845146968093)
-                await message.channel.send(fill_message("verify_verify_dumbshit",
+                await message.channel.send(utils.fill_message("verify_verify_dumbshit",
                                 user=message.author.id, emote=str(fp)))
                 return
 
@@ -210,7 +209,7 @@ class Verification(BaseFeature):
             if new_user is not None:
                 # Check the code
                 if code != new_user.code:
-                    await message.channel.send(fill_message("verify_verify_wrong_code",
+                    await message.channel.send(utils.fill_message("verify_verify_wrong_code",
                                     user=message.author.id))
                     embed = discord.Embed(title="Neuspesny pokus o verify(kod)",
                                           color=0xeee657)
@@ -225,9 +224,9 @@ class Verification(BaseFeature):
                 year = self.transform_year(new_user.year)
 
                 if year is None:
-                    await message.channel.send(fill_message("verify_verify_manual",
+                    await message.channel.send(utils.fill_message("verify_verify_manual",
                                                             user=message.author.id,
-                                                            toaster=Config.admin_id,
+                                                            admin=Config.admin_id,
                                                             year=str(new_user.year))
                     )
 
@@ -261,17 +260,17 @@ class Verification(BaseFeature):
 
                 self.repo.save_verified(login, message.author.id)
 
-                await message.channel.send(fill_message("verify_verify_success",
+                await message.channel.send(utils.fill_message("verify_verify_success",
                                 user=message.author.id))
 
                 await member.send(Messages.verify_post_verify_info)
 
                 if message.channel.type is not discord.ChannelType.private:
-                    await message.channel.send(fill_message("verify_verify_success",
+                    await message.channel.send(utils.fill_message("verify_verify_success",
                                     user=message.author.id))
             else:
-                await message.channel.send(fill_message("verify_verify_not_found",
-                                user=message.author.id, toaster=Config.admin_id))
+                await message.channel.send(utils.fill_message("verify_verify_not_found",
+                                user=message.author.id, admin=Config.admin_id))
 
                 embed = discord.Embed(title="Neuspesny pokus o verify",
                                       color=0xeee657)
@@ -281,8 +280,8 @@ class Verification(BaseFeature):
                 channel = self.bot.get_channel(Config.log_channel)
                 await channel.send(embed=embed)
         else:
-            await message.channel.send(fill_message("verify_verify_already_verified",
-                            user=message.author.id, toaster=Config.admin_id))
+            await message.channel.send(utils.fill_message("verify_verify_already_verified",
+                            user=message.author.id, admin=Config.admin_id))
 
         try:
             await message.delete()

--- a/features/verification.py
+++ b/features/verification.py
@@ -55,7 +55,7 @@ class Verification(BaseFeature):
         # Save the newly generated code into the database
         self.repo.save_sent_code(login, code)
 
-        await message.channel.send(utils.fill_message("verify_send_success", 
+        await message.channel.send(utils.fill_message("verify_send_success",
                                    user=message.author.id, mail=mail_postfix))
 
     async def send_code(self, message):
@@ -72,7 +72,7 @@ class Verification(BaseFeature):
             if login == "xlogin00":
                 guild = self.bot.get_guild(Config.guild_id)
                 fp = await guild.fetch_emoji(585915845146968093)
-                await message.channel.send(utils.fill_message("verify_send_dumbshit", 
+                await message.channel.send(utils.fill_message("verify_send_dumbshit",
                                            user=message.author.id, emote=str(fp)))
                 return
             if login[0] == 'x':

--- a/features/verification.py
+++ b/features/verification.py
@@ -56,7 +56,7 @@ class Verification(BaseFeature):
         self.repo.save_sent_code(login, code)
 
         await message.channel.send(utils.fill_message("verify_send_success", 
-                                    user=message.author.id, mail=mail_postfix))
+                                   user=message.author.id, mail=mail_postfix))
 
     async def send_code(self, message):
         if len(str(message.content).split(" ")) != 2:
@@ -83,7 +83,7 @@ class Verification(BaseFeature):
                                                       "@stud.fit.vutbr.cz")
                 else:
                     await message.channel.send(utils.fill_message("verify_send_not_found",
-                                   user=message.author.id, admin=Config.admin_id))
+                                               user=message.author.id, admin=Config.admin_id))
 
                     embed = discord.Embed(title="Neuspesny pokus o verify",
                                           color=0xeee657)
@@ -98,7 +98,7 @@ class Verification(BaseFeature):
                     int(login)
                 except ValueError:
                     await message.channel.send(utils.fill_message("verify_send_not_found",
-                                   user=message.author.id, admin=Config.admin_id))
+                                               user=message.author.id, admin=Config.admin_id))
 
                     embed = discord.Embed(title="Neuspesny pokus o verify",
                                           color=0xeee657)
@@ -120,7 +120,7 @@ class Verification(BaseFeature):
                                                       "@mail.muni.cz")
                 else:
                     await message.channel.send(utils.fill_message("verify_send_not_found",
-                                   user=message.author.id, admin=Config.admin_id))
+                                               user=message.author.id, admin=Config.admin_id))
 
                     embed = discord.Embed(title="Neuspesny pokus o verify",
                                           color=0xeee657)
@@ -131,7 +131,7 @@ class Verification(BaseFeature):
                     await channel.send(embed=embed)
         else:
             await message.channel.send(utils.fill_message("verify_already_verified",
-                            user=message.author.id, admin=Config.admin_id))
+                                       user=message.author.id, admin=Config.admin_id))
         try:
             await message.delete()
         except discord.errors.Forbidden:
@@ -194,14 +194,14 @@ class Verification(BaseFeature):
                 guild = self.bot.get_guild(Config.guild_id)
                 fp = await guild.fetch_emoji(585915845146968093)
                 await message.channel.send(utils.fill_message("verify_send_dumbshit",
-                                user=message.author.id, emote=str(fp)))
+                                           user=message.author.id, emote=str(fp)))
                 return
             # Same here
             if code == "kód" or code == "[kód]":
                 guild = self.bot.get_guild(Config.guild_id)
                 fp = await guild.fetch_emoji(585915845146968093)
                 await message.channel.send(utils.fill_message("verify_verify_dumbshit",
-                                user=message.author.id, emote=str(fp)))
+                                           user=message.author.id, emote=str(fp)))
                 return
 
             new_user = self.repo.get_user(login)
@@ -210,7 +210,7 @@ class Verification(BaseFeature):
                 # Check the code
                 if code != new_user.code:
                     await message.channel.send(utils.fill_message("verify_verify_wrong_code",
-                                    user=message.author.id))
+                                               user=message.author.id))
                     embed = discord.Embed(title="Neuspesny pokus o verify(kod)",
                                           color=0xeee657)
                     embed.add_field(name="User", value=utils.generate_mention(message.author.id))
@@ -224,10 +224,12 @@ class Verification(BaseFeature):
                 year = self.transform_year(new_user.year)
 
                 if year is None:
-                    await message.channel.send(utils.fill_message("verify_verify_manual",
-                                                            user=message.author.id,
-                                                            admin=Config.admin_id,
-                                                            year=str(new_user.year))
+                    await message.channel.send(utils.fill_message(
+                        "verify_verify_manual",
+                        user=message.author.id,
+                        admin=Config.admin_id,
+                        year=str(new_user.year)
+                        )
                     )
 
                     embed = discord.Embed(title="Neuspesny pokus o verify(manual)",
@@ -261,16 +263,16 @@ class Verification(BaseFeature):
                 self.repo.save_verified(login, message.author.id)
 
                 await message.channel.send(utils.fill_message("verify_verify_success",
-                                user=message.author.id))
+                                           user=message.author.id))
 
                 await member.send(Messages.verify_post_verify_info)
 
                 if message.channel.type is not discord.ChannelType.private:
                     await message.channel.send(utils.fill_message("verify_verify_success",
-                                    user=message.author.id))
+                                               user=message.author.id))
             else:
                 await message.channel.send(utils.fill_message("verify_verify_not_found",
-                                user=message.author.id, admin=Config.admin_id))
+                                           user=message.author.id, admin=Config.admin_id))
 
                 embed = discord.Embed(title="Neuspesny pokus o verify",
                                       color=0xeee657)
@@ -281,7 +283,7 @@ class Verification(BaseFeature):
                 await channel.send(embed=embed)
         else:
             await message.channel.send(utils.fill_message("verify_verify_already_verified",
-                            user=message.author.id, admin=Config.admin_id))
+                                       user=message.author.id, admin=Config.admin_id))
 
         try:
             await message.delete()

--- a/features/vote.py
+++ b/features/vote.py
@@ -170,21 +170,23 @@ class Vote(BaseFeature):
                     0]
 
             await chan.send(
-                content=self.singularise(messages.Messages.vote_result
-                                         .format(question=utils.escape_mentions(data.question),
-                                                 winning_emoji=most_voted.emoji,
-                                                 winning_option=utils.escape_mentions(option),
-                                                 votes=(most_voted.count - 1))))
+                content=self.singularise(utils.fill_message("vote_result",
+                    question=utils.escape_mentions(data.question),
+                    winning_emoji=most_voted.emoji,
+                    winning_option=utils.escape_mentions(option),
+                    votes=(most_voted.count - 1)
+            )))
         else:
             emoji_str = ""
             for e in all_most_voted:
                 emoji_str += str(e.emoji) + ", "
             emoji_str = emoji_str[:-2]
             await chan.send(
-                content=self.singularise(messages.Messages.vote_result_multiple
-                                         .format(question=utils.escape_mentions(data.question),
-                                                 winning_emojis=emoji_str,
-                                                 votes=(most_voted.count - 1))))
+                content=self.singularise(utils.fill_message("vote_result_multiple",
+                    question=utils.escape_mentions(data.question),
+                    winning_emojis=emoji_str,
+                    votes=(most_voted.count - 1)
+            )))
 
     # The lookups in this method are ineffective.
     # We could definitely get rid of all the iterations.
@@ -214,7 +216,7 @@ class Vote(BaseFeature):
 
         bot_msg = await target_msg.channel.history(limit=3,
                                                    after=target_msg.created_at) \
-            .get(author__id=self.bot.user.id)
+                                                   .get(author__id=self.bot.user.id)
 
         if bot_msg is None:
             return
@@ -235,17 +237,18 @@ class Vote(BaseFeature):
                     0]
 
             await bot_msg.edit(
-                content=self.singularise(messages.Messages.vote_winning.format(
-                    winning_emoji=most_voted.emoji,
-                    winning_option=option,
-                    votes=(most_voted.count - 1))))
+                content=self.singularise(utils.fill_message("vote_winning",
+                        winning_emoji=most_voted.emoji,
+                        winning_option=option,
+                        votes=(most_voted.count - 1)
+                )))
         else:
             emoji_str = ""
             for e in all_most_voted:
                 emoji_str += str(e.emoji) + ", "
             emoji_str = emoji_str[:-2]
             await bot_msg.edit(
-                content=self.singularise(
-                    messages.Messages.vote_winning_multiple
-                    .format(winning_emojis=emoji_str,
-                            votes=(most_voted.count - 1))))
+                content=self.singularise(utils.fill_message("vote_winning_multiple",
+                    winning_emojis=emoji_str,
+                    votes=(most_voted.count - 1)
+            )))

--- a/features/vote.py
+++ b/features/vote.py
@@ -222,9 +222,8 @@ class Vote(BaseFeature):
 
         bot_msg = await target_msg.channel.history(
             limit=3,
-            after=target_msg.created_at) \
-            .get(author__id=self.bot.user.id
-        )
+            after=target_msg.created_at
+        ).get(author__id=self.bot.user.id)
 
         if bot_msg is None:
             return

--- a/features/vote.py
+++ b/features/vote.py
@@ -170,23 +170,29 @@ class Vote(BaseFeature):
                     0]
 
             await chan.send(
-                content=self.singularise(utils.fill_message("vote_result",
+                content=self.singularise(utils.fill_message(
+                    "vote_result",
                     question=utils.escape_mentions(data.question),
                     winning_emoji=most_voted.emoji,
                     winning_option=utils.escape_mentions(option),
                     votes=(most_voted.count - 1)
-            )))
+                ))
+            )
         else:
             emoji_str = ""
             for e in all_most_voted:
                 emoji_str += str(e.emoji) + ", "
             emoji_str = emoji_str[:-2]
             await chan.send(
-                content=self.singularise(utils.fill_message("vote_result_multiple",
-                    question=utils.escape_mentions(data.question),
-                    winning_emojis=emoji_str,
-                    votes=(most_voted.count - 1)
-            )))
+                content=self.singularise(
+                    utils.fill_message(
+                        "vote_result_multiple",
+                        question=utils.escape_mentions(data.question),
+                        winning_emojis=emoji_str,
+                        votes=(most_voted.count - 1)
+                    )
+                )
+            )
 
     # The lookups in this method are ineffective.
     # We could definitely get rid of all the iterations.
@@ -214,9 +220,11 @@ class Vote(BaseFeature):
                                  target_msg.reactions):
                 await target_msg.add_reaction(reaction.emoji)
 
-        bot_msg = await target_msg.channel.history(limit=3,
-                                                   after=target_msg.created_at) \
-                                                   .get(author__id=self.bot.user.id)
+        bot_msg = await target_msg.channel.history(
+            limit=3,
+            after=target_msg.created_at) \
+            .get(author__id=self.bot.user.id
+        )
 
         if bot_msg is None:
             return
@@ -237,10 +245,11 @@ class Vote(BaseFeature):
                     0]
 
             await bot_msg.edit(
-                content=self.singularise(utils.fill_message("vote_winning",
-                        winning_emoji=most_voted.emoji,
-                        winning_option=option,
-                        votes=(most_voted.count - 1)
+                content=self.singularise(utils.fill_message(
+                    "vote_winning",
+                    winning_emoji=most_voted.emoji,
+                    winning_option=option,
+                    votes=(most_voted.count - 1)
                 )))
         else:
             emoji_str = ""
@@ -248,7 +257,11 @@ class Vote(BaseFeature):
                 emoji_str += str(e.emoji) + ", "
             emoji_str = emoji_str[:-2]
             await bot_msg.edit(
-                content=self.singularise(utils.fill_message("vote_winning_multiple",
-                    winning_emojis=emoji_str,
-                    votes=(most_voted.count - 1)
-            )))
+                content=self.singularise(
+                    utils.fill_message(
+                        "vote_winning_multiple",
+                        winning_emojis=emoji_str,
+                        votes=(most_voted.count - 1)
+                    )
+                )
+            )

--- a/logic/rng.py
+++ b/logic/rng.py
@@ -2,6 +2,7 @@ from datetime import date
 from random import randint, choice
 
 import utils
+from utils import fill_message
 from config.messages import Messages
 
 
@@ -31,8 +32,7 @@ class Rng:
             else:
                 y = 0
         except ValueError:
-            return Messages.rng_generator_format_number.format(
-                user=utils.generate_mention(message.author.id))
+            return fill_message("rng_generator_format_number", user=message.author.id)
         if x > y:
             x, y = y, x  # variable values swap
         return randint(x, y)

--- a/logic/rng.py
+++ b/logic/rng.py
@@ -2,7 +2,6 @@ from datetime import date
 from random import randint, choice
 
 import utils
-from utils import fill_message
 from config.messages import Messages
 
 
@@ -32,7 +31,7 @@ class Rng:
             else:
                 y = 0
         except ValueError:
-            return fill_message("rng_generator_format_number", user=message.author.id)
+            return utils.fill_message("rng_generator_format_number", user=message.author.id)
         if x > y:
             x, y = y, x  # variable values swap
         return randint(x, y)

--- a/logic/roll_dice.py
+++ b/logic/roll_dice.py
@@ -1,5 +1,6 @@
 from random import randint
 from re import match
+import utils
 
 from config.config import Config
 from config.messages import Messages
@@ -50,12 +51,12 @@ class Roll():
             return RollResult("(**0**)", 0)
 
         if dice_count > Config.max_dice_at_once:
-            raise SyntaxError(Messages.rd_too_many_dice_in_group
-                              .format(maximum=Config.max_dice_at_once))
+            raise SyntaxError(utils.fill_message("rd_too_many_dice_in_group",
+                              maximum=Config.max_dice_at_once))
 
         if dice_sides > Config.max_dice_sides:
-            raise SyntaxError(Messages.rd_too_many_dice_sides
-                              .format(maximum=Config.max_dice_sides))
+            raise SyntaxError(utils.fill_message("rd_too_many_dice_sides",
+                              maximum=Config.max_dice_sides))
 
         dice = [randint(1, dice_sides) for i in range(dice_count)]
 
@@ -173,8 +174,7 @@ class Roll():
         dice_groups = roll_string.split('+')
 
         if len(dice_groups) > Config.max_dice_groups:
-            return (Messages.rd_too_many_dice_groups
-                    .format(maximum=Config.max_dice_groups))
+            return utils.fill_message("rd_too_many_dice_groups", maximum=Config.max_dice_groups)
 
         for index, dice in enumerate(dice_groups):
             result = match(Roll.DICE_REGEX, dice)
@@ -184,7 +184,7 @@ class Roll():
                 except SyntaxError as e:
                     return str(e)
             else:
-                return Messages.rd_format.format(group=index)
+                return utils.fill_message("rd_format", group=index)
 
         returntext = ' + '.join(r.text for r in results)
         returntext += " = **" + str(sum(r.result for r in results)) + "**"

--- a/repository/review_repo.py
+++ b/repository/review_repo.py
@@ -12,7 +12,8 @@ class ReviewRepository(BaseRepository):
         super().__init__()
 
     def get_subject_reviews(self, subject):
-        return session.query(Review, func.count(Review.relevance)
+        return session.query(Review,
+            func.count(Review.relevance)
             .filter(ReviewRelevance.vote == True)
             .label('total')).filter(Review.subject == subject)\
             .outerjoin(Review.relevance).group_by(Review)\

--- a/repository/review_repo.py
+++ b/repository/review_repo.py
@@ -12,9 +12,10 @@ class ReviewRepository(BaseRepository):
         super().__init__()
 
     def get_subject_reviews(self, subject):
-        return session.query(Review,
+        return session.query(
+            Review,
             func.count(Review.relevance)
-            .filter(ReviewRelevance.vote == True)
+            .filter(ReviewRelevance.vote)
             .label('total')).filter(Review.subject == subject)\
             .outerjoin(Review.relevance).group_by(Review)\
             .order_by(desc('total'))
@@ -51,7 +52,7 @@ class ReviewRepository(BaseRepository):
             )
             session.add(review)
             session.commit()
-        except:
+        except Exception:
             session.rollback()
             raise
 

--- a/rubbergod.py
+++ b/rubbergod.py
@@ -4,14 +4,13 @@ import traceback
 from discord.ext import commands
 
 import utils
-from config import config, messages
-
+from config import config
 from features import presence
-from repository.review_repo import ReviewRepository
 from repository.database import database, session
 from repository.database.karma import Karma, Karma_emoji
-from repository.database.verification import Permit, Valid_person
 from repository.database.review import Review, ReviewRelevance, Subject
+from repository.database.verification import Permit, Valid_person
+from repository.review_repo import ReviewRepository
 
 
 # TODO move this ANYWHERE else
@@ -85,7 +84,6 @@ def load_dump():
 
 
 config = config.Config
-messages = messages.Messages
 
 bot = commands.Bot(command_prefix=commands.when_mentioned_or(
                                       *config.command_prefix),
@@ -128,9 +126,7 @@ async def pull(ctx):
         except:
             await ctx.send("Git pull error")
     else:
-        await ctx.send(
-            messages.insufficient_rights
-            .format(user=utils.generate_mention(ctx.author.id)))
+        await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
 
 
 @bot.command()
@@ -142,9 +138,7 @@ async def load(ctx, extension):
         except:
             await ctx.send("loading error")
     else:
-        await ctx.send(
-            messages.insufficient_rights
-            .format(user=utils.generate_mention(ctx.author.id)))
+        await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
 
 
 @bot.command()
@@ -156,9 +150,7 @@ async def unload(ctx, extension):
         except:
             await ctx.send("unloading error")
     else:
-        await ctx.send(
-            messages.insufficient_rights
-            .format(user=utils.generate_mention(ctx.author.id)))
+        await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
 
 
 @bot.command()
@@ -170,9 +162,7 @@ async def reload(ctx, extension):
         except:
             await ctx.send("reloading error")
     else:
-        await ctx.send(
-            messages.insufficient_rights
-            .format(user=utils.generate_mention(ctx.author.id)))
+        await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
 
 database.base.metadata.create_all(database.db)
 session.commit()  # Making sure

--- a/rubbergod.py
+++ b/rubbergod.py
@@ -85,8 +85,8 @@ def load_dump():
 
 config = config.Config
 
-bot = commands.Bot(command_prefix=commands.when_mentioned_or(
-                                      *config.command_prefix),
+bot = commands.Bot(
+    command_prefix=commands.when_mentioned_or(*config.command_prefix),
                    help_command=None,
                    case_insensitive=True)
 
@@ -123,7 +123,7 @@ async def pull(ctx):
         try:
             utils.git_pull()
             await ctx.send("Git pulled")
-        except:
+        except Exception:
             await ctx.send("Git pull error")
     else:
         await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
@@ -135,7 +135,7 @@ async def load(ctx, extension):
         try:
             bot.load_extension(f'cogs.{extension}')
             await ctx.send(f'{extension} loaded')
-        except:
+        except Exception:
             await ctx.send("loading error")
     else:
         await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
@@ -147,7 +147,7 @@ async def unload(ctx, extension):
         try:
             bot.unload_extension(f'cogs.{extension}')
             await ctx.send(f'{extension} unloaded')
-        except:
+        except Exception:
             await ctx.send("unloading error")
     else:
         await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
@@ -159,7 +159,7 @@ async def reload(ctx, extension):
         try:
             bot.reload_extension(f'cogs.{extension}')
             await ctx.send(f'{extension} reloaded')
-        except:
+        except Exception:
             await ctx.send("reloading error")
     else:
         await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
@@ -167,7 +167,7 @@ async def reload(ctx, extension):
 database.base.metadata.create_all(database.db)
 session.commit()  # Making sure
 
-#load_subjects()
+# load_subjects()
 
 for extension in config.extensions:
     bot.load_extension(f'cogs.{extension}')

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import git
 from discord import Member
+
 from config.messages import Messages
 
 
@@ -37,7 +38,7 @@ def has_role(user, role_name: str):
     return role_name.lower() in [x.name.lower() for x in user.roles]
 
 
-def fill_message(message_name, **kwargs):
+def fill_message(message_name, *args, **kwargs):
     """Fills message template from messages by attempting to get the attr.
     :param message_name: {str} message template name
     :kwargs: {dict} data for formatting the template
@@ -54,6 +55,6 @@ def fill_message(message_name, **kwargs):
     # Attempt to get message template and fill
     try:
         template = getattr(Messages, message_name)
-        return template.format(**kwargs)
+        return template.format(*args, **kwargs)
     except AttributeError:
         raise ValueError("Invalid template {}".format(message_name))

--- a/utils.py
+++ b/utils.py
@@ -51,7 +51,7 @@ def fill_message(message_name, *args, **kwargs):
 
     if 'admin' in kwargs:
         kwargs['admin'] = generate_mention(kwargs['admin'])
-    
+
     # Attempt to get message template and fill
     try:
         template = getattr(Messages, message_name)

--- a/utils.py
+++ b/utils.py
@@ -45,7 +45,7 @@ def fill_message(message_name, *args, **kwargs):
     :return: filled template
     """
 
-    # Convert username/toaster to a mention
+    # Convert username/admin to a mention
     if 'user' in kwargs:
         kwargs['user'] = generate_mention(kwargs['user'])
 

--- a/utils.py
+++ b/utils.py
@@ -48,12 +48,12 @@ def fill_message(message_name, **kwargs):
     if 'user' in kwargs:
         kwargs['user'] = generate_mention(kwargs['user'])
 
-    if 'toaster' in kwargs:
-        kwargs['toaster'] = generate_mention(kwargs['toaster'])
+    if 'admin' in kwargs:
+        kwargs['admin'] = generate_mention(kwargs['admin'])
     
     # Attempt to get message template and fill
     try:
         template = getattr(Messages, message_name)
         return template.format(**kwargs)
-    except Exception:
-        return ""
+    except AttributeError:
+        raise ValueError("Invalid template {}".format(message_name))

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import git
 from discord import Member
+from config.messages import Messages
 
 
 def generate_mention(user_id):
@@ -34,3 +35,25 @@ def has_role(user, role_name: str):
         return None
 
     return role_name.lower() in [x.name.lower() for x in user.roles]
+
+
+def fill_message(message_name, **kwargs):
+    """Fills message template from messages by attempting to get the attr.
+    :param message_name: {str} message template name
+    :kwargs: {dict} data for formatting the template
+    :return: filled template
+    """
+
+    # Convert username/toaster to a mention
+    if 'user' in kwargs:
+        kwargs['user'] = generate_mention(kwargs['user'])
+
+    if 'toaster' in kwargs:
+        kwargs['toaster'] = generate_mention(kwargs['toaster'])
+    
+    # Attempt to get message template and fill
+    try:
+        template = getattr(Messages, message_name)
+        return template.format(**kwargs)
+    except Exception:
+        return ""


### PR DESCRIPTION
I noticed the a reoccuring pattern in the codebase where `Messages.template` was being called with `generate_mention(...)` to generate a response. My idea is we could instead create a template engine that will generate the mentions and fill templates automatically. This change is just a concept, I'd just like to ask if you think it is a good idea @Toaster192.

This simple "filler" utility is the first step towards a less chaotic template generation. It takes the attribute name of the template from `Messages` and automatically generates mentions with kwargs that are named `user` or `toaster`.

I currently have no way to test if the code works as I only have rubbergod set up on my other computer, so I might add some bugfixes later.