### PR TITLE
Change exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker-compose down && docker-compose up --build
 * [Matthew](https://github.com/matejsoroka)
 * [Toaster](https://github.com/toaster192)
 * [Fpmk](https://github.com/TheGreatfpmK)
-* [_peter](https://github.com/xdragu01)
+* [_peter](https://github.com/peterdragun)
 * [Urumasi](https://github.com/Urumasi)
 * [Leo](https://github.com/ondryaso)
 

--- a/features/verification.py
+++ b/features/verification.py
@@ -136,7 +136,7 @@ class Verification(BaseFeature):
                                        user=message.author.id, admin=Config.admin_id))
         try:
             await message.delete()
-        except discord.errors.Forbidden:
+        except discord.errors.HTTPException:
             return
 
     @staticmethod


### PR DESCRIPTION
Sometimes, deleting message in DMs results in 404 error, not just 403. Switching to broader HTTPException.