### PR TITLE
Add author (and timestamp) into embed footers

### DIFF
--- a/cogs/karma.py
+++ b/cogs/karma.py
@@ -83,6 +83,7 @@ class Karma(commands.Cog):
             else:
                 karma_r.karma_emoji(ctx['message'].author, ctx['member'], ctx['emoji'].id)
 
+
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload):
         ctx = await utils.reaction_get_ctx(self.bot, payload)
@@ -193,7 +194,7 @@ class Karma(commands.Cog):
         if not await self.validate_leaderboard_offset(start, ctx):
             return
 
-        await self.karma.leaderboard(ctx.message.channel, 'get', 'DESC', start)
+        await self.karma.leaderboard(ctx, 'get', 'DESC', start)
         await self.check.botroom_check(ctx.message)
 
     @commands.cooldown(rate=2, per=30.0, type=commands.BucketType.user)
@@ -202,7 +203,7 @@ class Karma(commands.Cog):
         if not await self.validate_leaderboard_offset(start, ctx):
             return
 
-        await self.karma.leaderboard(ctx.message.channel, 'get', 'ASC', start)
+        await self.karma.leaderboard(ctx, 'get', 'ASC', start)
         await self.check.botroom_check(ctx.message)
 
     @commands.cooldown(rate=2, per=30.0, type=commands.BucketType.user)
@@ -211,7 +212,7 @@ class Karma(commands.Cog):
         if not await self.validate_leaderboard_offset(start, ctx):
             return
 
-        await self.karma.leaderboard(ctx.message.channel, 'give', 'DESC', start)
+        await self.karma.leaderboard(ctx, 'give', 'DESC', start)
         await self.check.botroom_check(ctx.message)
 
     @commands.cooldown(rate=2, per=30.0, type=commands.BucketType.user)
@@ -220,7 +221,7 @@ class Karma(commands.Cog):
         if not await self.validate_leaderboard_offset(start, ctx):
             return
 
-        await self.karma.leaderboard(ctx.message.channel, 'give', 'ASC', start)
+        await self.karma.leaderboard(ctx, 'give', 'ASC', start)
         await self.check.botroom_check(ctx.message)
 
     @leaderboard.error

--- a/cogs/review.py
+++ b/cogs/review.py
@@ -183,8 +183,8 @@ class Review(commands.Cog):
             value=f"http://fit.nechutny.net/?detail={subject.shortcut}",
             inline=False,
         )
-        embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
-        embed.set_footer(icon_url=ctx.author.avatar_url, text=ctx.author)
+
+        utils.add_author_footer(embed, ctx)
         await ctx.send(embed=embed)
 
     @commands.command()
@@ -230,7 +230,8 @@ class Review(commands.Cog):
         if year:
             degree = year
         embed.add_field(name="Program", value=degree)
-        embed.set_footer(icon_url=ctx.author.avatar_url, text=f"{ctx.author} | ?tierboard help")
+
+        utils.add_author_footer(embed, ctx, additional_text=" | ?tierboard help")
         await ctx.send(embed=embed)
 
     @reviews.error

--- a/cogs/review.py
+++ b/cogs/review.py
@@ -231,7 +231,7 @@ class Review(commands.Cog):
             degree = year
         embed.add_field(name="Program", value=degree)
 
-        utils.add_author_footer(embed, ctx, additional_text=" | ?tierboard help")
+        utils.add_author_footer(embed, ctx, additional_text=("?tierboard help",))
         await ctx.send(embed=embed)
 
     @reviews.error

--- a/cogs/urban.py
+++ b/cogs/urban.py
@@ -7,6 +7,7 @@ from urllib import parse as url_parse
 import discord
 from discord.ext import commands
 
+import utils
 from config.messages import Messages
 
 
@@ -33,8 +34,6 @@ class Urban(commands.Cog):
                 title=item["word"],
                 url=item["permalink"],
             )
-            embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
-            embed.set_footer(icon_url=ctx.author.avatar_url, text=ctx.author)
             embed.add_field(name="Definition", value=definition, inline=False)
             if example:
                 embed.add_field(name="Example", value=example, inline=False)
@@ -43,7 +42,10 @@ class Urban(commands.Cog):
                 value=f"{idx + 1}/{len(dict['list'])}",
                 inline=False,
             )
+            utils.add_author_footer(embed, ctx)
+
             embed_list.append(embed)
+
         return embed_list
 
     async def urban_pages(self, ctx, embeds):

--- a/cogs/weather.py
+++ b/cogs/weather.py
@@ -4,7 +4,7 @@ import discord
 from discord.ext import commands
 
 from config import app_config as config, messages
-
+import utils
 config = config.Config
 messages = messages.Messages
 
@@ -48,7 +48,11 @@ class weather(commands.Cog):
             embed.add_field(name="Vítr", value=wind, inline=True)
             embed.add_field(name="Oblačnost", value=clouds, inline=True)
             embed.add_field(name="Viditelnost", value=visibility, inline=True)
+
+            utils.add_author_footer(embed, ctx)
+
             await ctx.send(embed=embed)
+
         elif str(res["cod"]) == "404":
             await ctx.send("Město nenalezeno")
         elif str(res["cod"]) == "401":

--- a/cogs/week.py
+++ b/cogs/week.py
@@ -3,6 +3,7 @@ from datetime import date
 import discord
 from discord.ext import commands
 
+import utils
 from config import app_config as config, messages
 
 config = config.Config
@@ -24,9 +25,11 @@ class week(commands.Cog):
         stud_type = even if stud_week % 2 == 0 else odd
 
         embed = discord.Embed(title="Týden", color=0xE5DC37)
-        embed.set_footer(icon_url=ctx.author.avatar_url, text=str(ctx.author))
         embed.add_field(name="Studijní", value="{} ({})".format(stud_type, stud_week))
         embed.add_field(name="Kalendářní", value="{} ({})".format(cal_type, cal_week))
+
+        utils.add_author_footer(embed, ctx)
+
         await ctx.send(embed=embed)
 
 

--- a/features/karma.py
+++ b/features/karma.py
@@ -367,7 +367,7 @@ class Karma(BaseFeature):
             value = msg.karma_web if value_num == 1 else f"{msg.karma_web}{value_num}"
             embed.add_field(name=msg.karma_web_title, value=value)
 
-        message = await ctx.message.channel.send(embed=embed)
+        message = await ctx.send(embed=embed)
 
         await message.add_reaction("⏪")
         await message.add_reaction("◀")

--- a/features/karma.py
+++ b/features/karma.py
@@ -332,7 +332,7 @@ class Karma(BaseFeature):
 
         await channel_out.send(embed=embed)
 
-    async def leaderboard(self, channel, action, order, start=1):
+    async def leaderboard(self, ctx: discord.ext.commands.Context, action, order, start=1):
         if action == 'give':
             if order == "DESC":
                 column = 'positive'
@@ -360,14 +360,15 @@ class Karma(BaseFeature):
         output = self.gen_leaderboard_content(attribute, start, column)
 
         embed = discord.Embed(title=title, description=output)
-        embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+        utils.add_author_footer(embed, ctx)
 
         if action == "get" and order == "DESC":
             value_num = math.ceil(start / cfg.karma_grillbot_leaderboard_size)
             value = msg.karma_web if value_num == 1 else f"{msg.karma_web}{value_num}"
             embed.add_field(name=msg.karma_web_title, value=value)
 
-        message = await channel.send(embed=embed)
+        message = await ctx.message.channel.send(embed=embed)
+
         await message.add_reaction("⏪")
         await message.add_reaction("◀")
         await message.add_reaction("▶")

--- a/features/karma.py
+++ b/features/karma.py
@@ -327,8 +327,9 @@ class Karma(BaseFeature):
         elif karma < 0:
             colour = 0xcb410b
         embed.colour = colour
-        embed.set_footer(text=author, icon_url=author.avatar_url)
         embed.add_field(name='Celková karma za zprávu:', value=karma, inline=False)
+        utils.add_author_footer(embed, ctx=channel_out)
+
         await channel_out.send(embed=embed)
 
     async def leaderboard(self, channel, action, order, start=1):

--- a/utils.py
+++ b/utils.py
@@ -1,12 +1,12 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
-import git
 import discord
+import git
 from discord import Member
 from discord.ext import commands
 
-from config.messages import Messages
 from config.app_config import Config
+from config.messages import Messages
 
 
 def generate_mention(user_id):
@@ -93,7 +93,7 @@ def is_bot_admin(ctx: commands.Context):
 
 
 def cut_string(string: str, part_len: int):
-    return list(string[0 + i : part_len + i] for i in range(0, len(string), part_len))
+    return list(string[0 + i: part_len + i] for i in range(0, len(string), part_len))
 
 
 async def reaction_get_ctx(bot, payload):
@@ -138,3 +138,8 @@ async def helper_plus(ctx):
         if role.id in allowed_roles:
             return True
     raise NotHelperPlusError
+
+
+def add_author_footer(embed: discord.Embed, ctx: discord.ext.commands.Context):
+    embed.timestamp = datetime.now(tz=timezone.utc)
+    embed.set_footer(icon_url=ctx.author.avatar_url, text=ctx.author.name)

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Iterable
 
 import git
 import discord
@@ -141,8 +142,17 @@ async def helper_plus(ctx):
 
 
 def add_author_footer(embed: discord.Embed, ctx: discord.ext.commands.Context,
-                      set_timestamp=True, additional_text: str = ""):
+                      set_timestamp=True, additional_text: Iterable[str] = []):
+    """
+    Adds footer to the embed with author name and icon from ctx.
+
+    :param ctx: command Context object for author info
+    :param embed: discord.Embed object
+    :param set_timestamp: bool, should the embed's timestamp be set
+    :param additional_text: Iterable of strings that will be joined over " | " into one string
+    and added after author name.
+    """
+
     if set_timestamp:
         embed.timestamp = datetime.now(tz=timezone.utc)
-
-    embed.set_footer(icon_url=ctx.author.avatar_url, text=str(ctx.author)+additional_text)
+    embed.set_footer(icon_url=ctx.author.avatar_url, text=str(ctx.author) + ' | '.join(additional_text))

--- a/utils.py
+++ b/utils.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timezone
 from typing import Iterable
 
-import git
 import discord
+import git
 from discord import Member
 from discord.ext import commands
 
-from config.messages import Messages
 from config.app_config import Config
+from config.messages import Messages
 
 
 def generate_mention(user_id):
@@ -149,10 +149,11 @@ def add_author_footer(embed: discord.Embed, ctx: discord.ext.commands.Context,
     :param ctx: command Context object for author info
     :param embed: discord.Embed object
     :param set_timestamp: bool, should the embed's timestamp be set
-    :param additional_text: Iterable of strings that will be joined over " | " into one string
-    and added after author name.
+    :param additional_text: Iterable of strings that will be joined with author name by pipe symbol, eg.:
+    "john#2121 | text1 | text2".
     """
 
     if set_timestamp:
         embed.timestamp = datetime.now(tz=timezone.utc)
-    embed.set_footer(icon_url=ctx.author.avatar_url, text=str(ctx.author) + ' | '.join(additional_text))
+
+    embed.set_footer(icon_url=ctx.author.avatar_url, text=' | '.join((str(ctx.author), *additional_text)))

--- a/utils.py
+++ b/utils.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timezone
 
-import discord
 import git
+import discord
 from discord import Member
 from discord.ext import commands
 
-from config.app_config import Config
 from config.messages import Messages
+from config.app_config import Config
 
 
 def generate_mention(user_id):
@@ -140,6 +140,9 @@ async def helper_plus(ctx):
     raise NotHelperPlusError
 
 
-def add_author_footer(embed: discord.Embed, ctx: discord.ext.commands.Context):
-    embed.timestamp = datetime.now(tz=timezone.utc)
-    embed.set_footer(icon_url=ctx.author.avatar_url, text=ctx.author.name)
+def add_author_footer(embed: discord.Embed, ctx: discord.ext.commands.Context,
+                      set_timestamp=True, additional_text: str = ""):
+    if set_timestamp:
+        embed.timestamp = datetime.now(tz=timezone.utc)
+
+    embed.set_footer(icon_url=ctx.author.avatar_url, text=str(ctx.author)+additional_text)


### PR DESCRIPTION
Fixes #181

Added helper/util function for this and applied it to all cogs that have already used author footer in some way - making it look the same across all these cogs. This helper also handles if the embed should have timestamp.

Additionally added to `?weather` 

Don't know which other cogs should use this feature as it's kinda hard to test this locally, mainly because of missing database data/exact discord setup or basically _out-of-FIT_ context (eg. `?ios`) - needs more production testing:))

You can keep this PR open and just comment what other cogs/commands should implement this and I will add it.

EDIT:
Notes about other cogs:
`karma` and  `review` - uses footer for pagination, reviews already take a lot of space so jamming author+icon before/after the pagination might still work
