### PR TITLE
Bump discord.py to 1.5, add intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ wouldn't recommend using it for different servers.
 [Rubbergoddess](https://github.com/sinus-x/rubbergoddess) is a Rubbergod-based
 bot used on VUT FEKT discord server.
 
+## Creating discord application
+
+Before first run of bot you need to create discord application.
+Guide for creating new application and adding bot to your server can be found at
+discord.py [documentation](https://discordpy.readthedocs.io/en/latest/discord.html)
+
+While creating discord appilication one more step is required.
+Since `discord.py` v. 1.5 you will also need to enable `SERVER MEMBERS INTENT` in `Bot` tab.
+
 ## Installing and running the bot
 
 Prerequisites:
@@ -67,7 +76,7 @@ libpq-dev
 * [Matthew](https://github.com/matejsoroka)
 * [Toaster](https://github.com/toaster192)
 * [Fpmk](https://github.com/TheGreatfpmK)
-* [_peter](https://github.com/peterdragun)
+* [peter](https://github.com/peterdragun)
 * [Urumasi](https://github.com/Urumasi)
 * [Leo](https://github.com/ondryaso)
 * [sinus-x](https://github.com/sinus-x)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.7'
 services:
     db:
         image: postgres:12-alpine
+        environment:
+            POSTGRES_HOST_AUTH_METHOD: "trust"
         volumes:
             - postgres_data:/var/lib/postgresql/data/
     bot:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py >= 1.4.1
+discord.py >= 1.5.0
 emoji
 gitpython
 sqlalchemy

--- a/rubbergod.py
+++ b/rubbergod.py
@@ -2,7 +2,7 @@ import traceback
 import argparse
 import logging
 
-from discord import Embed, TextChannel, AllowedMentions
+from discord import Embed, TextChannel, AllowedMentions, Intents
 from discord.ext import commands
 
 import utils
@@ -42,11 +42,19 @@ elif args.init_db:
 config = Config
 is_initialized = False
 
+intents = Intents.none()
+intents.guilds = True
+intents.members = True
+intents.emojis = True
+intents.messages = True
+intents.reactions = True
+
 bot = commands.Bot(
     command_prefix=commands.when_mentioned_or(*config.command_prefix),
     help_command=None,
     case_insensitive=True,
     allowed_mentions=AllowedMentions(roles=False, everyone=False, users=True),
+    intents=intents,
 )
 
 presence = presence.Presence(bot)


### PR DESCRIPTION
As discord API has changed and looks like it requires intents to fetch some objects we have to update it or we will soon loose a lot of features.

Please note that updating application is required. Visit https://discord.com/developers/applications and in `Bot` card we need to enable `SERVER MEMBERS INTENT`. Adding this also to README so new users will be aware of this.

Updated README to include docs for discord application creation.