### PR TITLE
Fix urban cog error

### DIFF
--- a/cogs/urban.py
+++ b/cogs/urban.py
@@ -28,7 +28,7 @@ class Urban(commands.Cog):
             if len(definition) > 1024:
                 definition = definition[0:1021] + "`…`"
             if len(example) > 1024:
-                definition = definition[0:1021] + "`…`"
+                example = example[0:1021] + "`…`"
 
             embed = discord.Embed(
                 title=item["word"],


### PR DESCRIPTION
Wrong string was being shortened.
This error was already present in Amadeus, source of this cog.