### PR TITLE
use just one on_raw_reaction handler

### DIFF
--- a/cogs/autopin.py
+++ b/cogs/autopin.py
@@ -10,37 +10,30 @@ class AutoPin(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload):
+    async def hadle_reaction(self, ctx):
         """
         if the message has X or more 'pin' emojis pin the message
         """
-        channel = self.bot.get_channel(payload.channel_id)
-        if channel is None:
-            return
-        try:
-            message = await channel.fetch_message(payload.message_id)
-        except discord.errors.NotFound:
-            return
-        emoji = payload.emoji.name
-        if emoji == "📌":
-            for reaction in message.reactions:
-                if (
-                    reaction.emoji == "📌"
-                    and reaction.count >= Config.autopin_count
-                    and not message.pinned
-                    and message.type == discord.MessageType.default
-                    and message.channel.id not in Config.autopin_banned_channels
-                ):
-                    pin_count = await channel.pins()
-                    if len(pin_count) == 50:
-                        await channel.send(Messages.autopin_max_pins_error)
-                        return
-                    users = await reaction.users().flatten()
-                    await self.log(message, users)
-                    await message.pin()
-                    await message.clear_reaction("📌")
-                    break
+        reaction = ctx["emoji"]
+        message = ctx["message"]
+        channel = ctx["channel"]
+        for reaction in message.reactions:
+            if (
+                reaction.emoji == "📌"
+                and reaction.count >= Config.autopin_count
+                and not message.pinned
+                and message.type == discord.MessageType.default
+                and message.channel.id not in Config.autopin_banned_channels
+            ):
+                pin_count = await channel.pins()
+                if len(pin_count) == 50:
+                    await channel.send(Messages.autopin_max_pins_error)
+                    return
+                users = await reaction.users().flatten()
+                await self.log(message, users)
+                await message.pin()
+                await message.clear_reaction("📌")
+                break
 
     async def log(self, message, users):
         """

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -47,21 +47,15 @@ class Base(commands.Cog):
             await msg.add_reaction("◀")
             await msg.add_reaction("▶")
 
-    @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload):
-        ctx = await utils.reaction_get_ctx(self.bot, payload)
-        if ctx is None:
-            return
-
-        if ctx['message'].embeds and ctx['message'].embeds[0].title == "Rubbergod":
-            if ctx['emoji'] in ["◀", "▶"]:
-                page = int(ctx['message'].embeds[0].footer.text[5])
-                next_page = utils.pagination_next(ctx['emoji'], page, len(messages.info))
-                if next_page:
-                    embed = self.make_embed(next_page)
-                    await ctx['message'].edit(embed=embed)
-            if ctx['message'].guild: 
-                await ctx['message'].remove_reaction(ctx['emoji'], ctx['member'])
+    async def hadle_reaction(self, ctx):
+        if ctx['emoji'] in ["◀", "▶"]:
+            page = int(ctx['message'].embeds[0].footer.text[5])
+            next_page = utils.pagination_next(ctx['emoji'], page, len(messages.info))
+            if next_page:
+                embed = self.make_embed(next_page)
+                await ctx['message'].edit(embed=embed)
+        if ctx['message'].guild: 
+            await ctx['message'].remove_reaction(ctx['emoji'], ctx['member'])
 
     def make_embed(self, page):
         embed = discord.Embed(title="Rubbergod",

--- a/cogs/karma.py
+++ b/cogs/karma.py
@@ -21,15 +21,9 @@ class Karma(commands.Cog):
         self.karma = karma.Karma(bot, karma_r)
         self.check = room_check.RoomCheck(bot)
 
-    @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload):
-        ctx = await utils.reaction_get_ctx(self.bot, payload)
-        if ctx is None:
-            return
+    async def hadle_reaction(self, ctx):
         # grillbot emoji for removing message causes errors
         if ctx["emoji"] == "⏹️":
-            return
-        if ctx["channel"].id in config.role_channels:
             return
         # handle karma vote
         elif ctx["message"].content.startswith(messages.karma_vote_message_hack):

--- a/cogs/reactions.py
+++ b/cogs/reactions.py
@@ -1,0 +1,50 @@
+import discord
+from discord.ext import commands
+
+import utils
+from config.app_config import Config
+
+
+class Reaction(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload):
+        """Catch reaction, get all properties and then call proper cog/s"""
+        ctx = await utils.reaction_get_ctx(self.bot, payload)
+        if ctx is None:
+            return
+
+        cogs = []
+
+        if (
+            ctx["message"].embeds
+            and ctx["message"].embeds[0].title is not discord.Embed.Empty
+            and "reviews" in ctx["message"].embeds[0].title
+        ):
+            cogs.append(self.bot.get_cog("Review"))
+        if ctx["emoji"] == "📌":
+            cogs.append(self.bot.get_cog("AutoPin"))
+        if ctx["message"].embeds and ctx["message"].embeds[0].title == "Rubbergod":
+            cogs.append(self.bot.get_cog("Base"))
+        if ctx["channel"].id not in Config.role_channels:
+            cogs.append(self.bot.get_cog("Karma"))
+        else:
+            cogs.append(self.bot.get_cog("ReactToRole"))
+        if (
+            ctx["emoji"] == "❎"
+            and payload.channel_id in Config.deduplication_channels
+            and not payload.member.bot
+            and ctx["message"].author.bot
+        ):
+            cogs.append(self.bot.get_cog("Warden"))
+
+        for cog in cogs:
+            # check if cog is loaded
+            if cog:
+                await cog.hadle_reaction(ctx)
+
+
+def setup(bot):
+    bot.add_cog(Reaction(bot))

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -24,20 +24,14 @@ class ReactToRole(commands.Cog):
             role_data = await self.get_join_role_data(message)
             await self.message_role_reactions(message, role_data)
 
-    @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload):
-        ctx = await utils.reaction_get_ctx(self.bot, payload)
-        if ctx is None:
-            return
-
-        if ctx["channel"].id in Config.role_channels:
-            role_data = await self.get_join_role_data(ctx["message"])
-            for line in role_data:
-                if str(ctx["emoji"]) == line[1]:
-                    await self.add_perms(line[0], ctx["member"], ctx["guild"])
-                    break
-            else:
-                await ctx["message"].remove_reaction(ctx["emoji"], ctx["member"])
+    async def hadle_reaction(self, ctx):
+        role_data = await self.get_join_role_data(ctx["message"])
+        for line in role_data:
+            if str(ctx["emoji"]) == line[1]:
+                await self.add_perms(line[0], ctx["member"], ctx["guild"])
+                break
+        else:
+            await ctx["message"].remove_reaction(ctx["emoji"], ctx["member"])
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload):

--- a/cogs/warden.py
+++ b/cogs/warden.py
@@ -59,24 +59,9 @@ class Warden(commands.Cog):
                 except:
                     continue
 
-    @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+    async def hadle_reaction(self, ctx):
         """Delete duplicate embed if original is not a duplicate"""
-        if payload.channel_id not in config.deduplication_channels:
-            return
-        if payload.member.bot:
-            return
-        try:
-            message = (
-                await self.bot.get_guild(config.guild_id)
-                .get_channel(payload.channel_id)
-                .fetch_message(payload.message_id)
-            )
-        except Exception as e:
-            print("Warden:on_raw_reaction_add", "Message not found", e)
-            return
-        if not message or not message.author.bot:
-            return
+        message = ctx["message"]
 
         for react in message.reactions:
             if react.emoji == "❎" and react.count >= config.duplicate_limit:

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -26,7 +26,7 @@ db_string = "postgres://postgres:postgres@db:5432/postgres"
 
 [cogs]
 extensions = ['base', 'karma', 'meme', 'random', 'verify', 'fitwide', 'autopin', 'urban',
-    'acl', 'review', 'vote', 'kachna', 'name_day', 'week', 'weather', 'roles', 'error', 'absolvent', 'pet']
+    'acl', 'review', 'vote', 'kachna', 'name_day', 'week', 'weather', 'roles', 'error', 'absolvent', 'pet', 'reactions']
 
 [config]
 static = ['config_static', 'toml_dict', 'key', 'weather_token', 'db_string']


### PR DESCRIPTION
Just idea to use one reaction handler, as Menus will be soon implemented this won't be necessary, but currently we are experiencing low reaction time due to lock operation on every call of on_raw_reaction function. Let me know how you (dis)like this temp fix. Currently I have tested just reviews, if we would like this idea I will take closer look at other cogs as well.