### PR TITLE
fix `vote` wording, so that "11 hlasem" doesn't happen

### DIFF
--- a/features/vote.py
+++ b/features/vote.py
@@ -153,7 +153,7 @@ class Vote(BaseFeature):
 
     @staticmethod
     def singularise(msg: str):
-        return msg.replace("1 hlasy.", "1 hlasem.")
+        return msg.replace(" 1 hlasy.", " 1 hlasem.")
 
     async def send_winning_msg(self, channel_id, vote_msg_id, timeout):
         await asyncio.sleep(timeout)


### PR DESCRIPTION
A simple fix for this
![image](https://user-images.githubusercontent.com/35199722/103151972-4e026600-4783-11eb-97b2-e32cbaff2550.png)
Fixes #223 