### PR TITLE
fix stud_week being negative after new year's

### DIFF
--- a/cogs/week.py
+++ b/cogs/week.py
@@ -9,6 +9,9 @@ from config import app_config as config, messages
 config = config.Config
 messages = messages.Messages
 
+def get_last_year_week_count():
+    last_week = date(date.today().year - 1, 12, 28)
+    return last_week.isocalendar()[1]
 
 class week(commands.Cog):
     def __init__(self, bot):
@@ -20,6 +23,11 @@ class week(commands.Cog):
         """See if the current week is odd or even"""
         cal_week = date.today().isocalendar()[1]
         stud_week = cal_week - config.starting_week
+
+        # correct for stud_week being negative after new year's
+        if stud_week < 0:
+            stud_week += get_last_year_week_count()
+
         even, odd = "sudý", "lichý"
         cal_type = even if cal_week % 2 == 0 else odd
         stud_type = even if stud_week % 2 == 0 else odd


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/35199722/103835849-9f65fb80-5087-11eb-9ec7-42bb144cda7b.png)
Last year (2020) had 53 weeks and now, we're in 16th `stud_week`. If we take that -37 and add 53 to it, we get 16. Problem solved