### PR TITLE
Notify user about double quotes error

### DIFF
--- a/cogs/error.py
+++ b/cogs/error.py
@@ -24,7 +24,7 @@ class Error(commands.Cog):
             return
 
         if isinstance(error, commands.UserInputError):
-            await ctx.send("Chyba ve vstupu")
+            await ctx.send("Chyba ve vstupu, jestli vstup obsahuje `\"` nahraď je za `'`")
             return
 
         if isinstance(error, commands.CommandNotFound):


### PR DESCRIPTION
Sometimes there is error (especially in reviews) when message contains double quotes and bot responses just with general error and user doesn't know what is wrong. This should help user to identify errors in message.