### PR TITLE
Warden ignore users in marking false positives

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -107,6 +107,24 @@ class DynamicConfig(commands.Cog):
             toml.dump(Config.toml_dict, fd)
         await ctx.send(Messages.config_backup_created)
 
+    @config.command(brief=Messages.config_sync_template_brief)
+    async def sync_template(self, ctx):
+        path = os.path.dirname(__file__)[:-4]
+        config_path = f"{path}config/config.toml"
+        template = toml.load(f"{path}config/config.template.toml", _dict=dict)
+        for section in template:
+            if section in Config.toml_dict:
+                for key in template[section]:
+                    if key not in Config.toml_dict[section]:
+                        Config.toml_dict[section][key] = template[section][key]
+            else:
+                Config.toml_dict[section] = template[section]
+        with open(config_path, "w+") as fd:
+            toml.dump(Config.toml_dict, fd)
+        self.load_config()
+        await ctx.send(Messages.config_synced)
+        
+
     async def change_value(self, ctx, key: str, value: list, append: bool):
         """
         Changes config atrribute specified by `key` to `value`.

--- a/cogs/studijni.py
+++ b/cogs/studijni.py
@@ -1,0 +1,29 @@
+import discord
+from discord.ext import commands
+from lxml import etree
+import requests
+
+from config.messages import Messages
+from utils import add_author_footer
+
+class Studijni(commands.Cog):
+
+    @commands.command(brief=Messages.studijni_brief)
+    async def studijni(self, ctx):
+        link = "https://www.fit.vut.cz/fit/room/C109/.cs"
+        htmlparser = etree.HTMLParser()
+        session = requests.session()
+        result = session.get(link)
+        xDoc2 = etree.fromstring(result.text, htmlparser)
+        hours_div = xDoc2.xpath("//p[b[contains(text(),'Úřední hodiny')]]//following-sibling::div/p")
+        hours = etree.tostring(hours_div[0], encoding=str, method="text")
+        warning = etree.tostring(hours_div[1], encoding=str, method="text").split(':', 1)
+        embed = discord.Embed(title="C109 Studijní oddělení", url=link)
+        embed.add_field(name="Úřední hodiny", value=hours, inline=False)
+        embed.add_field(name=warning[0], value=warning[1], inline=False)
+        add_author_footer(embed, ctx.message.author)
+        await ctx.send(embed=embed)
+
+
+def setup(bot):
+    bot.add_cog(Studijni(bot))

--- a/cogs/warden.py
+++ b/cogs/warden.py
@@ -63,6 +63,10 @@ class Warden(commands.Cog):
         """Delete duplicate embed if original is not a duplicate"""
         message = ctx.message
 
+        if ctx.member.id in config.repost_ignore_users:
+            await message.remove_reaction("❎", ctx.member)
+            return
+
         for react in message.reactions:
             if react.emoji == "❎" and react.count >= config.duplicate_limit:
                 try:

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -133,6 +133,7 @@ class Config:
     # warden
     duplicate_limit: int = get_attr("warden", "duplicate_limit")
     deduplication_channels: List[int] = get_attr("warden", "deduplication_channels")
+    repost_ignore_users: List[int] = get_attr("warden", "repost_ignore_users")
 
     # week command
     starting_week: int = get_attr("week", "starting_week")

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -151,6 +151,7 @@ token = "678a5932f6dd92ac668b20e9f89c0318"
 duplicate_limit = 5
 #                           #memes              #aww
 deduplication_channels = [461548323116154880, 543083844736253964]
+repost_ignore_users = [0]
 
 [week]
 starting_week = 5

--- a/config/messages.py
+++ b/config/messages.py
@@ -373,3 +373,5 @@ class Messages:
     subscriptions_none = "Nebyly nalezeny žádné výsledky."
     subscriptions_missing_argument = "Musíš specifikovat kanál."
     subscriptions_bad_argument = "Musíš specifikovat kanál nebo uživatele."
+
+    studijni_brief = "Úřední hodiny studijního Oddělení"

--- a/config/messages.py
+++ b/config/messages.py
@@ -316,6 +316,8 @@ class Messages:
     config_backup_created = 'Config backup created'
     config_append_format = f'{prefix}config append [key] hodnota/y'
     config_list_invalid_regex = 'Chybný regex\n`{regex_err}`'
+    config_sync_template_brief = 'Synchronizuje config s template, přidá chybějíci klíče'
+    config_synced = 'Config byl synchronizován'
 
     channel_help = f"{prefix}channel [clone, copy]"
     channel_copy_help = f"{prefix}channel copy [source] [destination]"


### PR DESCRIPTION
Also adding option to load missing values from template to config. Currently we are just loking into template if key is missing but we are not able to edit those values. PR should fix this issue.