### PR TITLE
Fix help share and add warning about not opened courses

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -117,8 +117,11 @@ class Help(commands.Cog):
         param = request["parameters"]
         # mock ctx
         mock_message = copy.copy(message)
+        mock_view = commands.view.StringView("")
         mock_message.author = self.bot.get_user(param["user_id"])
         ctx = commands.Context(
+            bot=self.bot,
+            view=mock_view,
             prefix=config.default_prefix,
             message=mock_message,
         )

--- a/repository/review_repo.py
+++ b/repository/review_repo.py
@@ -147,18 +147,7 @@ class ReviewRepository(BaseRepository):
         session.merge(subject)
         session.commit()
 
-    def update_subject_type(self, shortcut, type, for_year):
-        subject = Subject_details(shortcut=shortcut, type=type, year=for_year)
-        session.merge(subject)
-        session.commit()
-
-    def update_subject_degree(self, shortcut, degree):
-        subject = Subject_details(shortcut=shortcut, degree=degree)
-        session.merge(subject)
-        session.commit()
-
-    def update_subject_sem(self, shortcut, sem):
-        subject = Subject_details(shortcut=shortcut, semester=sem)
+    def update_subject(self, subject: Subject_details):
         session.merge(subject)
         session.commit()
 


### PR DESCRIPTION
[help] Migration to disnake caused a change in the Context object, so now bot and view are mandatory fields for object creation.

[review] Adding support for updating subject names, which includes flag if the course is opened this year, adding embed field that will notify user that this course is not opened.