### PR TITLE
Raise Exception on None emoji in init_vote

### DIFF
--- a/cogs/vote.py
+++ b/cogs/vote.py
@@ -167,6 +167,10 @@ class Vote(commands.Cog):
                     e = vote.options[opt].emoji
                 else:
                     e = self.bot.get_emoji(int(vote.options[opt].emoji))
+                if e is None:
+                    raise Exception(
+                        f"Emoji(unicode={vote.options[opt].is_unicode}, name=\"{vote.options[opt].emoji}\") not found"
+                    )
                 await message.add_reaction(e)
 
         if vote.end_date is not None:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/xkinst01/.local/lib/python3.8/site-packages/disnake/client.py", line 531, in _run_event
    await coro(*args, **kwargs)
  File "/var/fitdiscord/rubbergod/cogs/vote.py", line 235, in on_ready
    await self.load_cached()
  File "/var/fitdiscord/rubbergod/cogs/vote.py", line 115, in load_cached
    await self.init_vote(msg)
  File "/var/fitdiscord/rubbergod/cogs/vote.py", line 170, in init_vote
    await message.add_reaction(e)
  File "/home/xkinst01/.local/lib/python3.8/site-packages/disnake/message.py", line 1672, in add_reaction
    emoji = convert_emoji_reaction(emoji)
  File "/home/xkinst01/.local/lib/python3.8/site-packages/disnake/message.py", line 120, in convert_emoji_reaction
    raise InvalidArgument(
disnake.errors.InvalidArgument: emoji argument must be str, Emoji, or Reaction not NoneType.
```
At least now we'll know what emoji causes this error :)