### PR TITLE
Fixed merlin users processing

### DIFF
--- a/cogs/fitwide.py
+++ b/cogs/fitwide.py
@@ -386,7 +386,8 @@ class FitWide(commands.Cog):
             login = line[0]
             name = line[4].split(",", 1)[0]
             try:
-                year = line[4].split(",")[1]
+                year_fields = line[4].split(',')[1].split(' ')
+                year = ' '.join(year_fields if not 'mail=' in year_fields[-1] else year_fields[-1])
             except IndexError:
                 continue
 

--- a/cogs/fitwide.py
+++ b/cogs/fitwide.py
@@ -130,7 +130,7 @@ class FitWide(commands.Cog):
                         await ctx.send("Status nesedí u: " + login)
 
                 year = self.verification.transform_year(person.year)
-                
+
                 if year is None:
                     year = "Dropout"
 
@@ -387,7 +387,8 @@ class FitWide(commands.Cog):
             name = line[4].split(",", 1)[0]
             try:
                 year_fields = line[4].split(',')[1].split(' ')
-                year = ' '.join(year_fields if not 'mail=' in year_fields[-1] else year_fields[-1])
+                year = ' '.join(year_fields if 'mail=' not in year_fields[-1] else year_fields[:-1])
+                mail = year_fields[-1].replace('mail=', '') if 'mail=' in year_fields[-1] else None
             except IndexError:
                 continue
 
@@ -399,7 +400,7 @@ class FitWide(commands.Cog):
                     year = year.replace("1r", "0r")
 
             found_people.append(Valid_person(login=login, year=year,
-                                             name=name))
+                                             name=name, mail=mail))
             found_logins.append(login)
 
         for login in found_logins:

--- a/cogs/random.py
+++ b/cogs/random.py
@@ -1,4 +1,3 @@
-from curses.panel import bottom_panel
 import random
 
 import disnake

--- a/features/verification.py
+++ b/features/verification.py
@@ -63,7 +63,7 @@ class Verification(BaseFeature):
         code = ''.join(random.choices(string.ascii_uppercase + string.digits, k=20))
 
         email_message = config.default_prefix + "verify "
-        email_message += user.login + " " + code
+        email_message += f"{user.login} {code}"
 
         mail_address = self.get_user_mail(user, mail_postfix)
         self.send_mail(mail_address, email_message)

--- a/repository/database/verification.py
+++ b/repository/database/verification.py
@@ -17,3 +17,4 @@ class Valid_person(database.base):
     year = Column(String)
     code = Column(String)
     status = Column(Integer, default=1)
+    mail = Column(String)

--- a/repository/user_repo.py
+++ b/repository/user_repo.py
@@ -50,12 +50,14 @@ class UserRepository(BaseRepository):
             .one_or_none()
         )
 
-    def add_user(self, login: str, year: str, status: int = 1):
+    def add_user(self, login: str, year: str, status: int = 1) -> Valid_person:
         """Add user to database"""
-        session.add(Valid_person(login=login, year=year, status=status))
+        person = Valid_person(login=login, year=year, status=status)
+        session.add(person)
         session.commit()
+        return person
 
-    def get_user_by_login(self, login: str):
+    def get_user_by_login(self, login: str) -> Valid_person:
         """Finds login from DB (without status check)"""
         user = (
             session.query(Valid_person).filter(Valid_person.login == login).one_or_none()


### PR DESCRIPTION
This PR adds support for new format in passwd file. Users now have an email address in the year, which causes complications when importing new users.

Old format:
```
xloginXX:x:15693:251:Login that you dont know,FIT BIT 42r:/homes/eva/xl/xloginXX:/bin/ksh
```

New format:
```
xloginXX:x:15693:251:Login that you dont know,FIT BIT 42r mail=xloginXX@stud.fit.vutbr.cz:/homes/eva/xl/xloginXX:/bin/ksh
```