### PR TITLE
add catch for interaction errors

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -163,7 +163,8 @@ class Help(commands.Cog):
             embed.set_footer(text=footer_text, icon_url=ctx.author.display_avatar.url)
             embeds.append(embed)
 
-        await ctx.reply(embed=embeds[0], view=EmbedView(embeds, author=ctx.author.id))
+        view = EmbedView(embeds, author=ctx.author.id)
+        view.message = await ctx.reply(embed=embeds[0], view=view)
 
 
 def setup(bot):

--- a/cogs/karma.py
+++ b/cogs/karma.py
@@ -156,9 +156,10 @@ class Karma(commands.Cog):
         await msg.add_reaction("🔁")
 
     @cooldowns.default_cooldown
-    @commands.group(brief=messages.karma_brief, usage=' ')
+    @commands.group()
     async def karma(self, ctx: commands.Context):
-        pass
+        if ctx.invoked_subcommand is None:
+            await ctx.reply(utils.fill_message("moved_command", invoked="karma"))
 
     @commands.check(utils.is_bot_admin)
     @karma.command(brief=messages.karma_revote_brief)

--- a/cogs/review.py
+++ b/cogs/review.py
@@ -60,7 +60,8 @@ class Review(commands.Cog):
             if embeds is None or len(embeds) == 0:
                 await ctx.reply(Messages.review_wrong_subject)
                 return
-            await ctx.reply(embed=embeds[0], view=ReviewView(self.bot, embeds))
+            view = ReviewView(self.bot, embeds)
+            view.message = await ctx.reply(embed=embeds[0], view=view)
 
     @reviews.command(brief=Messages.review_add_brief)
     async def add(self, ctx, subject=None, tier: int = None, *args):
@@ -257,7 +258,8 @@ class Review(commands.Cog):
             embed.description = ""
             embeds.append(embed)
 
-        await ctx.reply(embed=embeds[0], view=EmbedView(embeds))
+        view = EmbedView(embeds)
+        view.message = await ctx.reply(embed=embeds[0], view=view)
 
     @reviews.error
     @subject.error

--- a/cogs/streamlinks.py
+++ b/cogs/streamlinks.py
@@ -48,7 +48,8 @@ class StreamLinks(commands.Cog):
         embeds = []
         for idx, link in enumerate(streamlinks):
             embeds.append(self.create_embed_of_link(link, ctx.author, len(streamlinks), idx+1))
-        await ctx.reply(embed=embeds[0], view=EmbedView(embeds, timeout=180))
+        view = EmbedView(embeds, timeout=180)
+        view.message = await ctx.reply(embed=embeds[0], view=view)
 
     @commands.check(utils.helper_plus)
     @streamlinks.command(brief=Messages.streamlinks_add_brief)

--- a/cogs/urban.py
+++ b/cogs/urban.py
@@ -50,7 +50,8 @@ class Urban(commands.Cog):
 
     async def urban_pages(self, inter, embeds):
         """Send message and handle pagination for 300 seconds"""
-        await inter.response.send_message(embed=embeds[0], view=EmbedView(embeds))
+        view = EmbedView(embeds)
+        view.message = await inter.response.send_message(embed=embeds[0], view=view)
 
     @cooldowns.short_cooldown
     @commands.slash_command(name="urban", description=Messages.urban_brief)

--- a/features/karma.py
+++ b/features/karma.py
@@ -381,7 +381,7 @@ class Karma(BaseFeature):
             embed.add_field(name=Messages.karma_web_title, value=value)
 
         view = EmbedView([embed], roll_arroud=False, end_arrow=False, callback=self.update_embed)
-        await ctx.send(embed=embed, view=view)
+        view.message = await ctx.send(embed=embed, view=view)
 
     def gen_leaderboard_content(self, attribute, start, column):
         board = self.repo.get_leaderboard(attribute, start-1)


### PR DESCRIPTION
This PR will allow us to better understand errors in interactions with reporting to our bot-dev channel. Also adding the on_timeout method for removing interactions after timeout to reduce confusion.