### PR TITLE
Verify hotfix^4

### DIFF
--- a/features/verification.py
+++ b/features/verification.py
@@ -99,11 +99,12 @@ class Verification(BaseFeature):
                         user=inter.user.id,
                         admin=config.admin_ids[0],
                     )
-                    await inter.send(content=msg)
+                    await inter.edit_original_message(content=msg)
+                    await inter.followup.send(content=msg)
                     await self.log_verify_fail(
                         inter, "getcode (xlogin) - Unknown login", str({"login": login})
                     )
-                elif user is not None and user.status != VerifyStatus.Unverified.value:
+                elif user.status != VerifyStatus.Unverified.value:
                     if user.status == VerifyStatus.InProcess.value:
                         await self.gen_code_and_send_mail(inter, user, "stud.fit.vutbr.cz", dry_run=True)
                         return


### PR DESCRIPTION
This will actually send the same message twice because the first one is ephemeral. We need to end the deferred message and the second time to notify the admin about the missing login in DB.

Also removing unused logic folder