### PR TITLE
Add support for choosing custom icons

### DIFF
--- a/cogs/fitwide.py
+++ b/cogs/fitwide.py
@@ -134,7 +134,6 @@ class FitWide(commands.Cog):
 
                 correct_role = disnake.utils.get(guild.roles, name=year)
 
-
                 if correct_role not in member.roles:
                     for role_name, role in year_roles.items():
                         if role in member.roles and correct_role in weird_members[role].keys():

--- a/cogs/icons.py
+++ b/cogs/icons.py
@@ -67,34 +67,9 @@ class Icons(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.slash_command(description=Messages.icon_description)
+    @utils.PersistentCooldown(command_name="icon", limit=config.icon_ui_cooldown)
+    @commands.slash_command(description=Messages.icon_ui)
     async def icon(self, inter: disnake.ApplicationCommandInteraction):
-        pass
-
-    @commands.check(utils.helper_plus)
-    @icon.sub_command(description=Messages.icon_modset)
-    async def modset(
-        self,
-        inter: disnake.ApplicationCommandInteraction,
-        user: disnake.Member,
-        icon_s: str = commands.Param(autocomplete=icon_autocomp),
-    ):
-        icon_roles = get_icon_roles(inter.guild)
-        try:
-            icon = next(role for role in icon_roles if icon_s == icon_s.removeprefix(config.icon_role_prefix))
-        except StopIteration:
-            embed = disnake.Embed(title=Messages.icon_set_no_role)
-        else:
-            await self.do_set_icon(icon, user)
-            embed = disnake.Embed(
-                title=Messages.icon_set_success.format(user=user, icon=icon_name(icon)),
-            )
-
-        await inter.response.send_message(embed=embed, ephemeral=True)
-
-    @utils.PersistentCooldown(command_name="icon ui", limit=config.icon_ui_cooldown)
-    @icon.sub_command(description=Messages.icon_ui)
-    async def ui(self, inter: disnake.ApplicationCommandInteraction):
         await inter.response.defer(ephemeral=True)
         icon_roles = get_icon_roles(inter.guild)
         user = inter.user

--- a/cogs/icons.py
+++ b/cogs/icons.py
@@ -1,0 +1,88 @@
+from dis import dis
+from enum import auto
+from disnake.ext import commands
+from config.app_config import Config
+import utils
+import disnake
+from config.app_config import config
+from config.messages import Messages
+
+
+def icon_name(icon: disnake.Role):
+    return icon.name.removeprefix(config.icon_role_prefix)
+
+
+def get_icon_roles(guild: disnake.Guild):
+    return [role for role in guild.roles if role.id in config.icon_roles]
+
+
+async def icon_autocomp(inter: disnake.ApplicationCommandInteraction, partial: str):
+    icon_roles = get_icon_roles(inter.guild)
+    names = (icon_name(role) for role in icon_roles)
+    return [name for name in names if partial.casefold() in name.casefold()]
+
+
+class Icons(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def do_set_icon(self, icon: disnake.Role, user: disnake.Member):
+        """Set the icon to the user, removing any previous icons,
+        without checking whether the user is allowed to have said icon
+        """
+        icon_roles = get_icon_roles(user.guild)
+        current_roles = [role for role in user.roles if role in icon_roles]
+        if current_roles == [icon]:
+            return
+        if current_roles:
+            await user.remove_roles(*current_roles)
+        await user.add_roles(icon)
+
+    async def can_assign(self, icon: disnake.Role, user: disnake.Member):
+        """Whether a given user can have a given icon"""
+        rules = config.icon_rules[icon.id]
+        user_roles = {role.id for role in user.roles}
+        allow = rules.get("allow")
+        deny = rules.get("deny", [])
+        return (allow is None or not user_roles.isdisjoint(allow)) and user_roles.isdisjoint(deny)
+
+    @commands.slash_command(description=Messages.icon_description)
+    async def icon(self, inter: disnake.ApplicationCommandInteraction):
+        pass
+
+    @commands.check(utils.helper_plus)
+    @icon.sub_command(description=Messages.icon_modset)
+    async def modset(
+        self,
+        inter: disnake.ApplicationCommandInteraction,
+        user: disnake.Member,
+        icon_s: str = commands.Param(autocomplete=icon_autocomp),
+    ):
+        icon_roles = get_icon_roles(inter.guild)
+        try:
+            icon = next(role for role in icon_roles if icon_s == icon_name(icon))
+        except StopIteration:
+            embed = disnake.Embed(title=Messages.icon_set_no_role)
+        else:
+            await self.do_set_icon(icon, user)
+            embed = disnake.Embed(
+                title=Messages.icon_set_success.format(user=user, icon=icon_name(icon)),
+            )
+
+        await inter.response.send_message(embed=embed)
+
+    async def on_command_error(self, ctx: commands.Context, error):
+        if isinstance(error, commands.errors.CheckFailure):
+            await ctx.send(utils.fill_message("insufficient_rights", user=ctx.author.id))
+            return True
+        if isinstance(error, commands.errors.CommandInvokeError):
+            if isinstance(error.__cause__, commands.errors.ExtensionAlreadyLoaded):
+                await ctx.send(utils.fill_message("cog_is_loaded", cog=error.__cause__.name))
+                return True
+            elif isinstance(error.__cause__, commands.errors.ExtensionNotLoaded):
+                await ctx.send(utils.fill_message("cog_is_unloaded", cog=error.__cause__.name))
+                return True
+
+
+def setup(bot):
+    bot.add_cog(Icons(bot))

--- a/cogs/icons.py
+++ b/cogs/icons.py
@@ -20,7 +20,8 @@ async def can_assign(icon: disnake.Role, user: disnake.Member):
     user_roles = {role.id for role in user.roles}
     allow = rules.get("allow")
     deny = rules.get("deny", [])
-    return (allow is None or not user_roles.isdisjoint(allow)) and user_roles.isdisjoint(deny)
+    allowed_by_role = (allow is None or not user_roles.isdisjoint(allow)) and user_roles.isdisjoint(deny)
+    return allowed_by_role and user.id not in deny
 
 
 async def do_set_icon(icon: disnake.Role, user: disnake.Member):

--- a/cogs/icons.py
+++ b/cogs/icons.py
@@ -103,10 +103,10 @@ class Icons(commands.Cog):
             for icon in icon_roles
             if await can_assign(icon, user)
         ]
-        assert len(options) <= 25  # TODO: remove this limit
-        component = IconSelect(placeholder=Messages.icon_ui_choose, options=options)
         view = BaseView()
-        view.add_item(component)
+        for start_i in range(0, len(options), 25):
+            component = IconSelect(placeholder=Messages.icon_ui_choose, options=options[start_i:start_i+25])
+            view.add_item(component)
         await inter.edit_original_message(view=view)
 
     async def cog_slash_command_error(self, inter: disnake.ApplicationCommandInteraction, error: Exception) -> None:

--- a/cogs/icons.py
+++ b/cogs/icons.py
@@ -49,7 +49,9 @@ class IconSelect(disnake.ui.Select):
             return
         user = inter.user
         if await can_assign(icon, user):
-            await inter.edit_original_message(Messages.icon_set_success.format(user=inter.user, icon=icon), view=None)
+            await inter.edit_original_message(
+                Messages.icon_set_success.format(user=inter.user, icon=icon), view=None
+            )
             await do_set_icon(icon, user)
         else:
             await inter.edit_original_message(Messages.icon_ui_no_permission)
@@ -105,11 +107,15 @@ class Icons(commands.Cog):
         ]
         view = BaseView()
         for start_i in range(0, len(options), 25):
-            component = IconSelect(placeholder=Messages.icon_ui_choose, options=options[start_i:start_i+25])
+            component = IconSelect(
+                placeholder=Messages.icon_ui_choose, options=options[start_i: start_i + 25]
+            )
             view.add_item(component)
         await inter.edit_original_message(view=view)
 
-    async def cog_slash_command_error(self, inter: disnake.ApplicationCommandInteraction, error: Exception) -> None:
+    async def cog_slash_command_error(
+        self, inter: disnake.ApplicationCommandInteraction, error: Exception
+    ) -> None:
         if isinstance(error, commands.CommandOnCooldown):
             await inter.response.send_message(str(error), ephemeral=True)
             return True

--- a/cogs/icons.py
+++ b/cogs/icons.py
@@ -50,7 +50,7 @@ class IconSelect(disnake.ui.Select):
         user = inter.user
         if await can_assign(icon, user):
             await inter.edit_original_message(
-                Messages.icon_set_success.format(user=inter.user, icon=icon), view=None
+                Messages.icon_set_success.format(user=inter.user, icon=icon_name(icon)), view=None
             )
             await do_set_icon(icon, user)
         else:
@@ -92,7 +92,7 @@ class Icons(commands.Cog):
 
         await inter.response.send_message(embed=embed, ephemeral=True)
 
-    @commands.cooldown(1, config.icon_ui_cooldown)
+    @utils.PersistentCooldown(command_name="icon ui", limit=config.icon_ui_cooldown)
     @icon.sub_command(description=Messages.icon_ui)
     async def ui(self, inter: disnake.ApplicationCommandInteraction):
         await inter.response.defer(ephemeral=True)
@@ -116,7 +116,7 @@ class Icons(commands.Cog):
     async def cog_slash_command_error(
         self, inter: disnake.ApplicationCommandInteraction, error: Exception
     ) -> None:
-        if isinstance(error, commands.CommandOnCooldown):
+        if isinstance(error, utils.PCommandOnCooldown):
             await inter.response.send_message(str(error), ephemeral=True)
             return True
 

--- a/cogs/icons.py
+++ b/cogs/icons.py
@@ -1,7 +1,5 @@
-from dis import dis
-from enum import auto
 from disnake.ext import commands
-from config.app_config import Config
+from buttons.base import BaseView
 import utils
 import disnake
 from config.app_config import config
@@ -16,6 +14,46 @@ def get_icon_roles(guild: disnake.Guild):
     return [role for role in guild.roles if role.id in config.icon_roles]
 
 
+async def can_assign(icon: disnake.Role, user: disnake.Member):
+    """Whether a given user can have a given icon"""
+    rules = config.icon_rules[icon.id]
+    user_roles = {role.id for role in user.roles}
+    allow = rules.get("allow")
+    deny = rules.get("deny", [])
+    return (allow is None or not user_roles.isdisjoint(allow)) and user_roles.isdisjoint(deny)
+
+
+async def do_set_icon(icon: disnake.Role, user: disnake.Member):
+    """Set the icon to the user, removing any previous icons,
+    without checking whether the user is allowed to have said icon
+    """
+    icon_roles = get_icon_roles(user.guild)
+    current_roles = [role for role in user.roles if role in icon_roles]
+    if current_roles == [icon]:
+        return
+    if current_roles:
+        await user.remove_roles(*current_roles)
+    await user.add_roles(icon)
+
+
+class IconSelect(disnake.ui.Select):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+    async def callback(self, inter: disnake.MessageInteraction):
+        await inter.response.defer(ephemeral=True)
+        [choice] = self.values
+        icon = disnake.utils.get(inter.guild.roles, id=int(choice))
+        if icon is None:
+            await inter.edit_original_message(Messages.icon_ui_fail)
+            return
+        user = inter.user
+        if await can_assign(icon, user):
+            await do_set_icon(icon, user)
+        else:
+            await inter.edit_original_message(Messages.icon_ui_no_permission)
+
+
 async def icon_autocomp(inter: disnake.ApplicationCommandInteraction, partial: str):
     icon_roles = get_icon_roles(inter.guild)
     names = (icon_name(role) for role in icon_roles)
@@ -25,26 +63,6 @@ async def icon_autocomp(inter: disnake.ApplicationCommandInteraction, partial: s
 class Icons(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-
-    async def do_set_icon(self, icon: disnake.Role, user: disnake.Member):
-        """Set the icon to the user, removing any previous icons,
-        without checking whether the user is allowed to have said icon
-        """
-        icon_roles = get_icon_roles(user.guild)
-        current_roles = [role for role in user.roles if role in icon_roles]
-        if current_roles == [icon]:
-            return
-        if current_roles:
-            await user.remove_roles(*current_roles)
-        await user.add_roles(icon)
-
-    async def can_assign(self, icon: disnake.Role, user: disnake.Member):
-        """Whether a given user can have a given icon"""
-        rules = config.icon_rules[icon.id]
-        user_roles = {role.id for role in user.roles}
-        allow = rules.get("allow")
-        deny = rules.get("deny", [])
-        return (allow is None or not user_roles.isdisjoint(allow)) and user_roles.isdisjoint(deny)
 
     @commands.slash_command(description=Messages.icon_description)
     async def icon(self, inter: disnake.ApplicationCommandInteraction):
@@ -69,7 +87,25 @@ class Icons(commands.Cog):
                 title=Messages.icon_set_success.format(user=user, icon=icon_name(icon)),
             )
 
-        await inter.response.send_message(embed=embed)
+        await inter.response.send_message(embed=embed, ephemeral=True)
+
+    @icon.sub_command(description=Messages.icon_ui)
+    async def ui(self, inter: disnake.ApplicationCommandInteraction):
+        await inter.response.defer(ephemeral=True)
+        icon_roles = get_icon_roles(inter.guild)
+        user = inter.user
+        options = [
+            disnake.SelectOption(
+                label=icon_name(icon), value=str(icon.id), emoji=getattr(icon, "_icon", None)
+            )
+            for icon in icon_roles
+            if await can_assign(icon, user)
+        ]
+        assert len(options) <= 25  # TODO: remove this limit
+        component = IconSelect(placeholder=Messages.icon_ui_choose, options=options)
+        view = BaseView()
+        view.add_item(component)
+        await inter.edit_original_message("A", view=view)
 
     async def on_command_error(self, ctx: commands.Context, error):
         if isinstance(error, commands.errors.CheckFailure):

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict
 import toml
 
 
@@ -158,6 +158,11 @@ class Config:
 
     # room check
     enable_room_check: bool = get_attr(toml_dict, "random", "enable_room_check")
+
+    # icons
+    icon_roles: List[int] = get_attr(toml_dict, "icons", "icon_roles")
+    icon_role_prefix: str = get_attr(toml_dict, "icons", "role_prefix")
+    icon_rules: Dict[int, Dict[str, List[int]]] = {int(k): v for k, v in get_attr(toml_dict, "icons", "rule").items()}
 
 
 config = Config()

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -163,6 +163,7 @@ class Config:
     icon_roles: List[int] = get_attr(toml_dict, "icons", "icon_roles")
     icon_role_prefix: str = get_attr(toml_dict, "icons", "role_prefix")
     icon_rules: Dict[int, Dict[str, List[int]]] = {int(k): v for k, v in get_attr(toml_dict, "icons", "rule").items()}
+    icon_ui_cooldown: float = get_attr(toml_dict, "icons", "ui_cooldown")
 
 
 config = Config()

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -162,7 +162,9 @@ class Config:
     # icons
     icon_roles: List[int] = get_attr(toml_dict, "icons", "icon_roles")
     icon_role_prefix: str = get_attr(toml_dict, "icons", "role_prefix")
-    icon_rules: Dict[int, Dict[str, List[int]]] = {int(k): v for k, v in get_attr(toml_dict, "icons", "rule").items()}
+    icon_rules: Dict[int, Dict[str, List[int]]] = {
+        int(k): v for k, v in get_attr(toml_dict, "icons", "rule").items()
+    }
     icon_ui_cooldown: float = get_attr(toml_dict, "icons", "ui_cooldown")
 
 

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -154,4 +154,4 @@ ui_cooldown = 10.0
 [icons.rule.0]
 allow=[] # prevent anyone from self-assigning this role
 [icons.rule.1]
-deny=[461550034668748800] # prevent mods from self-assigning this role (they can use modset to bypass)
+deny=[461550034668748800, 140547421733126145] # prevent mods and the user arcasCZ from self-assigning this icon via the UI.

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -150,6 +150,7 @@ subscribe_default_guild = true
 [icons]
 icon_roles = [0,1]
 role_prefix = "Ikona: "
+ui_cooldown = 10.0
 [icons.rule.0]
 allow=[] # prevent anyone from self-assigning this role
 [icons.rule.1]

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -146,3 +146,11 @@ paginator_duration = 60
 term_channels = ["1bit-terminy", "2bit-terminy", "3bit-terminy", "mit-terminy"]
 terms_update_interval = 0.5 # Update interval in days for automatic updating
 subscribe_default_guild = true
+
+[icons]
+icon_roles = [0,1]
+role_prefix = "Ikona: "
+[icons.rule.0]
+allow=[] # prevent anyone from self-assigning this role
+[icons.rule.1]
+deny=[461550034668748800] # prevent mods from self-assigning this role (they can use modset to bypass)

--- a/config/messages.py
+++ b/config/messages.py
@@ -415,8 +415,6 @@ class Messages:
     bookmark_created = "Záložka **{title_name}** vytvořena"
     bookmark_upload_limit = "Zpráva obsahuje přílohu přesahující upload limit, doporučuji si tuto přílohu stáhnout. V připadě smazání původní zprávy nebude příloha dostupná."
 
-    icon_description = "Příkazy pro práci s ikonami"
-    icon_modset = "Přidání ikony uživateli, jen pro helper+, ignoruje podmínky"
     icon_ui = "UI pro přiřazení ikony"
     icon_set_success = "Užiteli {user} nastavena ikona {icon}"
     icon_set_no_role = "Vstup neodpovídá žádné možné ikoně"

--- a/config/messages.py
+++ b/config/messages.py
@@ -414,3 +414,9 @@ class Messages:
     blocked_bot = "Nemůžu ti posílat zprávy {user}"
     bookmark_created = "Záložka **{title_name}** vytvořena"
     bookmark_upload_limit = "Zpráva obsahuje přílohu přesahující upload limit, doporučuji si tuto přílohu stáhnout. V připadě smazání původní zprávy nebude příloha dostupná."
+
+    icon_description = "Příkazy pro práci s ikonami"
+    icon_modset = "Přidání ikony uživateli, jen pro helper+, ignoruje podmínky"
+    icon_ui = "UI pro přiřazení ikony"
+    icon_set_success = "Užiteli {user} nastavena ikona {icon}"
+    icon_set_no_role = "Vstup neodpovídá žádné možné ikoně"

--- a/config/messages.py
+++ b/config/messages.py
@@ -423,3 +423,5 @@ class Messages:
     icon_ui_choose = "Vyber si ikonu"
     icon_ui_fail = "Nastavit ikonu se nepodařilo"
     icon_ui_no_permission = "Na tuto ikonu nemáš právo"
+
+    cooldown = "Příliš rychle, zkus to znovu za {:.3}s"

--- a/config/messages.py
+++ b/config/messages.py
@@ -420,3 +420,6 @@ class Messages:
     icon_ui = "UI pro přiřazení ikony"
     icon_set_success = "Užiteli {user} nastavena ikona {icon}"
     icon_set_no_role = "Vstup neodpovídá žádné možné ikoně"
+    icon_ui_choose = "Vyber si ikonu"
+    icon_ui_fail = "Nastavit ikonu se nepodařilo"
+    icon_ui_no_permission = "Na tuto ikonu nemáš právo"

--- a/repository/database/cooldown.py
+++ b/repository/database/cooldown.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, String, Integer
+
+from repository.database import database
+
+
+class Cooldown(database.base):
+    __tablename__ = "cooldowns"
+
+    command_name = Column(String, primary_key=True, nullable=False)
+    user_id = Column(String, primary_key=True, nullable=False)
+    timestamp = Column(Integer, nullable=False)


### PR DESCRIPTION
Implements a slash command `/icon ui`, which allows any member to pick their role icon, which will show up next to their name
 - Can be configured to only allow a given role icon to members with a certain role - see config.template.toml
 - Can be configured to deny a given role icon if a member has a certain role
 - Supports cooldown