### PR TITLE
Fix '??' message being treated as a command

### DIFF
--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -1,7 +1,7 @@
 [base]
 command_prefix = ['?', '!']
 default_prefix = '?'
-ignored_prefixes = ['!']
+ignored_prefixes = ['?', '!']
 key = ''
 admin_ids = [0]  # first ID is used for mention in case of false verification
 guild_id = 0

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -1,7 +1,7 @@
 [base]
 command_prefix = ['?', '!']
 default_prefix = '?'
-ignored_prefixes = ['?', '!']
+ignored_prefixes = ['?', '!'] # ignore messages like '??' and '?!'
 key = ''
 admin_ids = [0]  # first ID is used for mention in case of false verification
 guild_id = 0


### PR DESCRIPTION
**Issue:** Whenever anyone on the server types `??` as a 'WTF' reaction, the bot treats it like a normal command and sends `Messages.no_such_command`. 

**Fix:** Add `??` to `ignored_prefixes` (in a similar way as `!?`).