### PR TITLE
Fix: Treat '??' as a normal message, not a command

### DIFF
--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -58,6 +58,11 @@ class Meme(commands.Cog):
     async def uhoh(self, inter):
         await inter.send(utils.fill_message("uhoh_counter", uhohs=uhoh_counter))
 
+    # Ignore '??'
+    @commands.command(name="?")
+    async def ignore_questionmark(self, ctx):
+        pass
+
     @cooldowns.short_cooldown
     @commands.command(name="??", brief="???")
     async def question(self, ctx):


### PR DESCRIPTION
**Issue:** Whenever anyone on the server types `??` as a 'WTF' reaction, the bot treats it like a normal command and sends `Messages.no_such_command`.

**Fix:** Add `??` as a command that doesn't do anything.

Thx to @solumath for working proposal