### PR TITLE
Exam as slash commands

### DIFF
--- a/buttons/review.py
+++ b/buttons/review.py
@@ -100,7 +100,7 @@ class ReviewView(EmbedView):
             if not ((self.perma_lock or self.locked) and interaction.author.id != self.author.id):
                 self.check_text_pages()
                 # update view
-                await interaction.edit_original_message(view=self)
+                await interaction.edit_original_response(view=self)
             return False
         elif "text" in interaction.data.custom_id and self.embed.fields[3].name == "Text page":
             if (self.perma_lock or self.locked) and interaction.author.id != self.author.id:

--- a/cogs/absolvent.py
+++ b/cogs/absolvent.py
@@ -44,14 +44,14 @@ class Absolvent(commands.Cog):
         """
         await inter.response.defer(with_message=True, ephemeral=True)
         if thesis_web_id == "19121":
-            await inter.edit_original_message(Messages.absolvent_id_from_help)
+            await inter.edit_original_response(Messages.absolvent_id_from_help)
             return
 
         # prepare
         htmlparser = etree.HTMLParser()
         diploma_year = re.search(r"\d+/(\d+)", diploma_number)
         if not diploma_year:
-            await inter.edit_original_message(Messages.absolvent_wrong_diploma_format)
+            await inter.edit_original_response(Messages.absolvent_wrong_diploma_format)
             return
         diploma_year = diploma_year.group(1)
         full_name_without_degree_surname_first = f"{surname}, {name}"
@@ -69,7 +69,7 @@ class Absolvent(commands.Cog):
         name_from_user_without_diacritics = remove_accents(f"{surname} {name}")
 
         if name_from_db != name_from_user_without_diacritics:
-            await inter.edit_original_message(Messages.absolvent_wrong_name)
+            await inter.edit_original_response(Messages.absolvent_wrong_name)
             return
 
         # CHECK OWNERSHIP, TYPE AND YEAR OF THE QUALIFICATION WORK / THESIS
@@ -120,7 +120,7 @@ class Absolvent(commands.Cog):
             )
         )
 
-        # await inter.edit_original_message(f"""
+        # await inter.edit_original_response(f"""
         # DEBUG:
         # nf: {not_found}
         # mt: {master_thesis}
@@ -132,12 +132,12 @@ class Absolvent(commands.Cog):
         # """)
 
         if "Page cannot be found" in not_found:
-            await inter.edit_original_message(Messages.absolvent_thesis_not_found_error)
+            await inter.edit_original_response(Messages.absolvent_thesis_not_found_error)
             return
 
         habilitation_year = re.search(r"(\d+)-\d+-\d+", habilitation_date)
         if habilitation_year is None:
-            await inter.edit_original_message(Messages.absolvent_thesis_not_found_error)
+            await inter.edit_original_response(Messages.absolvent_thesis_not_found_error)
             return
         habilitation_year = habilitation_year.group(1)
 
@@ -148,7 +148,7 @@ class Absolvent(commands.Cog):
             and result == "práce byla úspěšně obhájena"
             and thesis_author_without_degree_surname_first == full_name_without_degree_surname_first
         ):
-            await inter.edit_original_message(Messages.absolvent_web_error)
+            await inter.edit_original_response(Messages.absolvent_web_error)
             return
 
         # DIPLOMA VALIDITY CHECK
@@ -189,7 +189,7 @@ class Absolvent(commands.Cog):
             and "úspěšně ověřen" in absolventText
             and absolventText.endswith(", Fakulta informačních technologií")
         ):
-            await inter.edit_original_message(Messages.absolvent_diploma_error)
+            await inter.edit_original_response(Messages.absolvent_diploma_error)
             return
 
         guild = self.bot.get_guild(config.guild_id)
@@ -204,11 +204,11 @@ class Absolvent(commands.Cog):
                 if "Dropout" in drop_role.name:
                     await member.remove_roles(drop_role, reason="Diploma verification")
             await member.add_roles(role)
-            await inter.edit_original_message(Messages.absolvent_success)
+            await inter.edit_original_response(Messages.absolvent_success)
 
     @diplom.error
     async def diplom_error(self, inter: disnake.ApplicationCommandInteraction, error):
-        await inter.edit_original_message(
+        await inter.edit_original_response(
             utils.fill_message("absolvent_help", command=inter.application_command)
         )
 

--- a/cogs/exams.py
+++ b/cogs/exams.py
@@ -56,7 +56,7 @@ class Exams(commands.Cog):
     @terms.sub_command(name="update", description=Messages.exams_update_term_brief)
     async def update(self, inter: disnake.ApplicationCommandInteraction):
         updated_chans = await self.update_exam_terms(inter.guild, inter.author)
-        await inter.edit_original_message(utils.fill_message("exams_terms_updated", num_chan=updated_chans))
+        await inter.edit_original_response(utils.fill_message("exams_terms_updated", num_chan=updated_chans))
 
     @commands.check(utils.is_bot_admin_or_mod)
     @terms.sub_command(name="remove_all", description=Messages.exams_remove_all_terms_brief)
@@ -74,13 +74,13 @@ class Exams(commands.Cog):
                             await message.delete()
                         except disnake.NotFound:
                             pass
-        await inter.edit_original_message(Messages.exams_terms_removed)
+        await inter.edit_original_response(Messages.exams_terms_removed)
 
     @commands.check(utils.is_bot_admin_or_mod)
     @terms.sub_command(name="remove", description=Messages.exams_remove_terms_brief)
     async def remove(self, inter: disnake.ApplicationCommandInteraction, channel: disnake.TextChannel):
         if not isinstance(channel, disnake.TextChannel):
-            return await inter.edit_original_message(
+            return await inter.edit_original_response(
                 utils.fill_message("exams_channel_is_not_text_channel", chan_name=channel.name)
             )
 
@@ -205,9 +205,9 @@ class Exams(commands.Cog):
                         if rocnik is not None:
                             return await self.process_exams(inter, rocnik, inter.author)
 
-                await inter.edit_original_message(Messages.exams_no_valid_role)
+                await inter.edit_original_response(Messages.exams_no_valid_role)
             else:
-                await inter.edit_original_message(Messages.exams_specify_year)
+                await inter.edit_original_response(Messages.exams_specify_year)
         else:
             await self.process_exams(inter, rocnik, inter.author)
 
@@ -417,7 +417,7 @@ class Exams(commands.Cog):
             pages.append(embed)
         if isinstance(ctx, disnake.ApplicationCommandInteraction):
             view = EmbedView(ctx.author, pages)
-            view.message = await ctx.response.edit_message(embed=pages[0], view=view)
+            view.message = await ctx.edit_original_response(embed=pages[0], view=view)
         else:
             header = disnake.Embed(
                 title=title, description=description, color=disnake.Color.dark_blue()

--- a/cogs/fit_room.py
+++ b/cogs/fit_room.py
@@ -24,7 +24,7 @@ class FitRoom(commands.Cog):
         url = f"https://www.fit.vut.cz/fit/map/.cs?show={room.upper()}&big=1"
         r = requests.get(url)
         if r.status_code != 200:
-            return await inter.edit_original_message(Messages.fit_room_unreach)
+            return await inter.edit_original_response(Messages.fit_room_unreach)
 
         try:
             soup = BeautifulSoup(r.content, 'html.parser')
@@ -34,10 +34,10 @@ class FitRoom(commands.Cog):
             image = main_body.find("svg", {"id": "map"})
             cursor = main_body.find("polygon", {"id": "arrow"})
         except AttributeError:
-            return await inter.edit_original_message(Messages.fit_room_parsing_failed)
+            return await inter.edit_original_response(Messages.fit_room_parsing_failed)
 
         if image is None or cursor is None:
-            return await inter.edit_original_message(
+            return await inter.edit_original_response(
                 utils.fill_message("fit_room_room_not_on_plan", room=room[:1024])
                 )
 
@@ -56,7 +56,7 @@ class FitRoom(commands.Cog):
         embed.description = f"[Odkaz na plánek]({url})"
         utils.add_author_footer(embed, inter.author, additional_text=[str(active_floor.text)])
         file = disnake.File(fp=image_bytes, filename="plan.png")
-        await inter.edit_original_message(embed=embed, file=file)
+        await inter.edit_original_response(embed=embed, file=file)
 
 
 def setup(bot):

--- a/cogs/fit_room.py
+++ b/cogs/fit_room.py
@@ -17,7 +17,7 @@ class FitRoom(commands.Cog):
     @commands.slash_command(name="room", description=Messages.fit_room_brief)
     async def room(
         self,
-        inter,
+        inter: disnake.ApplicationCommandInteraction,
         room: str
     ):
         await inter.response.defer()

--- a/cogs/icons.py
+++ b/cogs/icons.py
@@ -54,16 +54,16 @@ class IconSelect(disnake.ui.Select):
         [choice] = self.values
         icon = disnake.utils.get(inter.guild.roles, id=int(choice))
         if icon is None:
-            await inter.edit_original_message(Messages.icon_ui_fail)
+            await inter.edit_original_response(Messages.icon_ui_fail)
             return
         user = inter.user
         if await can_assign(icon, user):
-            await inter.edit_original_message(
+            await inter.edit_original_response(
                 Messages.icon_set_success.format(user=inter.user, icon=icon_name(icon)), view=None
             )
             await do_set_icon(icon, user)
         else:
-            await inter.edit_original_message(Messages.icon_ui_no_permission)
+            await inter.edit_original_response(Messages.icon_ui_no_permission)
 
 
 async def icon_autocomp(inter: disnake.ApplicationCommandInteraction, partial: str):
@@ -102,7 +102,7 @@ class Icons(commands.Cog):
                 placeholder=Messages.icon_ui_choose, options=options[start_i: start_i + 25], row=0,
             )
             view.add_item(component)
-        await inter.edit_original_message(view=view)
+        await inter.edit_original_response(view=view)
 
     @commands.Cog.listener()
     async def on_button_click(self, inter: disnake.MessageInteraction):

--- a/cogs/karma.py
+++ b/cogs/karma.py
@@ -173,7 +173,7 @@ class Karma(commands.Cog):
     ):
         await inter.response.defer(with_message=True, ephemeral=ephemeral)
         embed = await self.karma.message_karma(inter.author, message)
-        await inter.edit_original_message(embed=embed)
+        await inter.edit_original_response(embed=embed)
         msg = await inter.original_message()
         if not ephemeral:
             await msg.add_reaction("🔁")

--- a/cogs/name_day.py
+++ b/cogs/name_day.py
@@ -56,13 +56,13 @@ class Nameday(commands.Cog):
     async def name_day_cz(self, inter: disnake.ApplicationCommandInteraction):
         await inter.response.defer()
         name_day_cz = await self._name_day_cz()
-        await inter.edit_original_message(name_day_cz)
+        await inter.edit_original_response(name_day_cz)
 
     @commands.slash_command(name="meniny", description=Messages.name_day_sk_brief)
     async def name_day_sk(self, inter: disnake.ApplicationCommandInteraction):
         await inter.response.defer()
         name_day_sk = await self._name_day_sk()
-        await inter.edit_original_message(name_day_sk)
+        await inter.edit_original_response(name_day_sk)
 
     @tasks.loop(time=time(7, 0, tzinfo=local_tz))
     async def send_names(self):

--- a/cogs/review.py
+++ b/cogs/review.py
@@ -67,7 +67,7 @@ class Review(commands.Cog):
     @commands.slash_command(name="review")
     async def reviews(self, inter: disnake.ApplicationCommandInteraction):
         """Group of commands for reviews."""
-        pass
+        await inter.response.defer()
 
     @reviews.sub_command(name='get', description=Messages.review_get_brief)
     async def get(
@@ -81,7 +81,7 @@ class Review(commands.Cog):
             await inter.send(Messages.review_wrong_subject)
             return
         view = ReviewView(inter.author, self.bot, embeds)
-        await inter.response.send_message(embed=embeds[0], view=view)
+        await inter.response.edit_message(embed=embeds[0], view=view)
         view.message = await inter.original_message()
 
     @reviews.sub_command(name='add', description=Messages.review_add_brief)
@@ -93,7 +93,7 @@ class Review(commands.Cog):
         text: str = None
     ):
         """Add new review for `subject`"""
-        # TODO: use modal in future when disnake 2.6 released
+        # TODO: use modal in future when disnake 2.8?? released
         # await inter.response.send_modal(modal=ReviewModal(self.bot))
         if not await self.check_member(inter):
             return

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -311,14 +311,14 @@ class Roles(commands.Cog):
         await inter.send(Messages.channel_copy_start)
         for key in src.overwrites:
             await dst.set_permissions(key, overwrite=src.overwrites[key])
-        await inter.edit_original_message(Messages.channel_copy_done)
+        await inter.edit_original_response(Messages.channel_copy_done)
 
     @channel.sub_command(name="clone", description=Messages.role_channel_clone_brief)
     async def clone(self, inter, src: Union[disnake.TextChannel, disnake.VoiceChannel], name):
         """Clone channel with same permissions as src."""
         await inter.send(Messages.channel_clone_start)
         new = await src.clone(name=name)
-        await inter.edit_original_message(utils.fill_message("channel_clone_done", id=new.id))
+        await inter.edit_original_response(utils.fill_message("channel_clone_done", id=new.id))
 
     @channel.sub_command(name="create", description=Messages.role_channel_create_brief)
     async def create(
@@ -338,11 +338,11 @@ class Roles(commands.Cog):
         for index, member in enumerate(role.members):
             await channel.set_permissions(member, view_channel=True)
             if (index % rate == 0):
-                await inter.edit_original_message(
+                await inter.edit_original_response(
                     f"• uživatelů: {len(role.members)}\n" + utils.create_bar(index+1, len(role.members))
                 )
 
-        await inter.edit_original_message(
+        await inter.edit_original_response(
             utils.fill_message(
                 "channel_create_done",
                 channel=channel.mention,

--- a/cogs/streamlinks.py
+++ b/cogs/streamlinks.py
@@ -67,14 +67,14 @@ class StreamLinks(commands.Cog):
         streamlinks = self.streamlinks_repo.get_streamlinks_of_subject(subject.lower())
 
         if len(streamlinks) == 0:
-            await inter.edit_original_message(content=Messages.streamlinks_no_stream)
+            await inter.edit_original_response(content=Messages.streamlinks_no_stream)
             return
 
         embeds = []
         for idx, link in enumerate(streamlinks):
             embeds.append(self.create_embed_of_link(link, inter.author, len(streamlinks), idx+1))
         view = EmbedView(inter.author, embeds, timeout=180)
-        view.message = await inter.edit_original_message(embed=embeds[0], view=view)
+        view.message = await inter.edit_original_response(embed=embeds[0], view=view)
 
     @commands.check(utils.helper_plus)
     @_streamlinks.sub_command(name="add", description=Messages.streamlinks_add_brief)
@@ -92,7 +92,7 @@ class StreamLinks(commands.Cog):
         link = utils.clear_link_escape(link)
 
         if self.streamlinks_repo.exists_link(link):
-            await inter.edit_original_message(
+            await inter.edit_original_response(
                 utils.fill_message('streamlinks_add_link_exists', user=inter.author.id)
             )
             return
@@ -117,7 +117,7 @@ class StreamLinks(commands.Cog):
             link_data['image'],
             link_data['upload_date']
         )
-        await inter.edit_original_message(content=Messages.streamlinks_add_success)
+        await inter.edit_original_response(content=Messages.streamlinks_add_success)
 
     @_streamlinks.sub_command(name="list", description=Messages.streamlinks_list_brief)
     async def streamlinks_list(
@@ -159,7 +159,7 @@ class StreamLinks(commands.Cog):
 
         await inter.response.defer()
         if not self.streamlinks_repo.exists(id):
-            await inter.edit_original_message(Messages.streamlinks_not_exists)
+            await inter.edit_original_response(Messages.streamlinks_not_exists)
             return
 
         stream = self.streamlinks_repo.get_stream_by_id(id)

--- a/cogs/studijni.py
+++ b/cogs/studijni.py
@@ -35,7 +35,7 @@ class Studijni(commands.Cog):
                 hours = Messages.studijni_web_error
         embed.add_field(name=Messages.studijni_office_hours, value=hours, inline=False)
         add_author_footer(embed, inter.author)
-        await inter.edit_original_message(embed=embed)
+        await inter.edit_original_response(embed=embed)
 
 
 def setup(bot):

--- a/cogs/urban.py
+++ b/cogs/urban.py
@@ -50,7 +50,7 @@ class Urban(commands.Cog):
     async def urban_pages(self, inter, embeds):
         """Send message and handle pagination for 300 seconds"""
         view = EmbedView(inter.author, embeds)
-        view.message = await inter.edit_original_message(embed=embeds[0], view=view)
+        view.message = await inter.edit_original_response(embed=embeds[0], view=view)
 
     @cooldowns.short_cooldown
     @commands.slash_command(name="urban", description=Messages.urban_brief)
@@ -63,9 +63,9 @@ class Urban(commands.Cog):
             response.raise_for_status()
 
         except requests.HTTPError as http_err:
-            await inter.edit_original_message(f"HTTP error occurred: {http_err}")
+            await inter.edit_original_response(f"HTTP error occurred: {http_err}")
         except Exception as err:
-            await inter.edit_original_message(f"Error occurred: {err}")
+            await inter.edit_original_response(f"Error occurred: {err}")
         else:
             # Request was successful
             embeds = self.urban_embeds(inter.author, dict)
@@ -73,7 +73,7 @@ class Urban(commands.Cog):
         if embeds:
             await self.urban_pages(inter, embeds)
         else:
-            await inter.edit_original_message(Messages.urban_not_found)
+            await inter.edit_original_response(Messages.urban_not_found)
         return
 
 

--- a/cogs/weather.py
+++ b/cogs/weather.py
@@ -19,7 +19,7 @@ class Weather(commands.Cog):
 
         place = place[:100]
         if "&" in place:
-            return await inter.edit_original_message("Takhle se žádné město určitě nejmenuje.")
+            return await inter.edit_original_response("Takhle se žádné město určitě nejmenuje.")
 
         url = (
             "http://api.openweathermap.org/data/2.5/weather?q="
@@ -51,14 +51,14 @@ class Weather(commands.Cog):
 
             utils.add_author_footer(embed, inter.author)
 
-            await inter.edit_original_message(embed=embed)
+            await inter.edit_original_response(embed=embed)
 
         elif str(res["cod"]) == "404":
-            await inter.edit_original_message("Město nenalezeno")
+            await inter.edit_original_response("Město nenalezeno")
         elif str(res["cod"]) == "401":
-            await inter.edit_original_message("Rip token -> Rebel pls fix")
+            await inter.edit_original_response("Rip token -> Rebel pls fix")
         else:
-            await inter.edit_original_message(
+            await inter.edit_original_response(
                 "Město nenalezeno! <:pepeGun:484470874246742018> (" + res["message"] + ")"
             )
 

--- a/config/messages.py
+++ b/config/messages.py
@@ -403,7 +403,7 @@ class Messages:
 
     meme_repost_link = "[Odkaz na originál]({original_message_url}) v <#{original_channel}>"
 
-    exams_brief = f"{prefix}exams [rocnik] pro zobrazení zkoušek pro daný ročník a nebo bez ročníku pro ročník podle role"
+    exams_brief = f"Zobrazí zkoušky pro daný ročník (výchozí ročník podle role)"
     exams_no_valid_role = "Nebyla nalezena ročníková role"
     exams_specify_year = "Specifikuj ročník"
     exams_no_valid_year = "Byl zadán neplatný ročník"

--- a/features/verification.py
+++ b/features/verification.py
@@ -75,7 +75,7 @@ class Verification(BaseFeature):
 
         if not is_resend:
             view = VerifyWithResendButtonView(user.login)
-            await inter.edit_original_message(content=success_message, view=view)
+            await inter.edit_original_response(content=success_message, view=view)
         else:
             view = VerifyView(user.login)
             await inter.response.edit_message(content=success_message, view=view)
@@ -99,7 +99,7 @@ class Verification(BaseFeature):
                         user=inter.user.id,
                         admin=config.admin_ids[0],
                     )
-                    await inter.edit_original_message(content=msg)
+                    await inter.edit_original_response(content=msg)
                     await inter.followup.send(content=msg)
                     await self.log_verify_fail(
                         inter, "getcode (xlogin) - Unknown login", str({"login": login})
@@ -113,7 +113,7 @@ class Verification(BaseFeature):
                         user=inter.user.id,
                         admin=config.admin_ids[0],
                     )
-                    await inter.edit_original_message(content=msg)
+                    await inter.edit_original_response(content=msg)
                     await self.log_verify_fail(
                         inter,
                         "getcode (xlogin) - Invalid verify state",
@@ -127,7 +127,7 @@ class Verification(BaseFeature):
                     int(login)
                 except ValueError:
                     msg = utils.fill_message("invalid_login", user=inter.user.id, admin=config.admin_ids[0])
-                    await inter.edit_original_message(msg)
+                    await inter.edit_original_response(msg)
                     await self.log_verify_fail(inter, "getcode (MUNI)", str({"login": login}))
 
                 user = self.repo.get_user_by_login(login)
@@ -288,7 +288,7 @@ class Verification(BaseFeature):
     async def send_xlogin_info(self, inter: disnake.ApplicationCommandInteraction):
         guild = self.bot.get_guild(config.guild_id)
         fp = await guild.fetch_emoji(585915845146968093)
-        await inter.edit_original_message(
+        await inter.edit_original_response(
             content=utils.fill_message("verify_send_dumbshit", user=inter.user.id, emote=str(fp))
         )
 


### PR DESCRIPTION
Convert both user and admin commands in the exams cog to slash commands.
This PR also includes the following:
- defer reviews get
- rename `edit_original_message` to `edit_original_response` as this was renamed in Disnake 2.6, see docs: https://docs.disnake.dev/en/stable/api.html#disnake.Interaction.edit_original_response
`Changed in version 2.6: This function was renamed from edit_original_message.`