### PR TITLE
Vote unknown emoji

### DIFF
--- a/cogs/vote.py
+++ b/cogs/vote.py
@@ -54,8 +54,8 @@ class VoteMessage:
         matches = cls.emoji_regex.match(opt_line)
         if matches is None:
             # it is not a disnake emoji, try unicode
-            emojis = emoji.emoji_lis(opt_line)
-            if len(emojis) > 0 and emojis[0]['location'] == 0:
+            emojis = emoji.emoji_list(opt_line)
+            if len(emojis) > 0 and emojis[0]['match_start'] == 0:
                 opt_emoji = emojis[0]['emoji']
                 opt_message = opt_line[len(opt_emoji):].strip()
             else:

--- a/config/messages.py
+++ b/config/messages.py
@@ -83,7 +83,7 @@ class Messages:
     karma_vote_allvoted = "Už se hlasovalo o všech emotech."
     karma_revote_format = "Očekávám pouze formát " \
                           f"`{prefix}karma revote [emote]`"
-    karma_emote_not_found = "Emote jsem na serveru nenašel."
+    emote_not_found = "Emote `{emote}` jsem na serveru nenašel."
     karma_get_format = "Použití:\n" \
                        "`/karma getall`: " \
                        "vypíše všechny emoty s hodnotou.\n" \

--- a/features/karma.py
+++ b/features/karma.py
@@ -119,7 +119,7 @@ class Karma(BaseFeature):
                 await message.channel.send(Messages.karma_revote_format)
                 return
             except disnake.NotFound:
-                await message.channel.send(Messages.karma_emote_not_found)
+                await message.channel.send(utils.fill_message("emote_not_found", emote=emoji))
                 return
 
         vote_value = await self.emoji_process_vote(message.channel, emoji)
@@ -141,7 +141,7 @@ class Karma(BaseFeature):
                 await inter.response.send_message(Messages.karma_get_format)
                 return
             except disnake.NotFound:
-                await inter.response.send_message(Messages.karma_emote_not_found)
+                await inter.response.send_message(utils.fill_message("emote_not_found", emote=emoji))
                 return
 
         val = self.repo.emoji_value_raw(emoji)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 disnake>=2.7.0
-emoji
+emoji>=2.0.0
 gitpython
 sqlalchemy
 psycopg2-binary


### PR DESCRIPTION
Add catch for unknown emoji from different servers -> applicable for nitro users.
Users will be notified on the first unknown emoji, and the rest of the message will be ignored.

Found a deprecation in `emoji` lib with our implementation -> updating requirement and implementation.