### PR TITLE
change output of "group list", "group add" check if group already exists

### DIFF
--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -277,7 +277,7 @@ class Roles(commands.Cog):
     @group.sub_command(name="list", description=Messages.group_list)
     async def groups(self, inter):
         names = group_repo.group_names()
-        groups = "\n".join([str(name) for name in names])
+        groups = "\n".join(names)
         output = utils.cut_string_by_words(groups, 1900, "\n")
         await inter.send(f"```md\n# ACTIVE GROUPS:\n{output[0]}```")
         for message in output[1:]:

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -277,11 +277,11 @@ class Roles(commands.Cog):
     @group.sub_command(name="list", description=Messages.group_list)
     async def groups(self, inter):
         names = group_repo.group_names()
-        groups = '\n'.join([str(name) for name in names])
-        output = utils.cut_string(groups, 1900)
-        output[0] = f"```md\n# ACTIVE GROUPS:\n{output[0]}```"
-        for message in output:
-            await inter.send(message)
+        groups = "\n".join([str(name) for name in names])
+        output = utils.cut_string_by_words(groups, 1900, "\n")
+        await inter.send(f"```md\n# ACTIVE GROUPS:\n{output[0]}```")
+        for message in output[1:]:
+            await inter.channel.send(f"```md\n{message}```")
 
     @group.sub_command(name="add_channel_id", description=Messages.group_add_channel_id)
     async def add_channel_id(self, inter, name: str, channel_id: str):

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -256,8 +256,12 @@ class Roles(commands.Cog):
 
     @group.sub_command(name="add", description=Messages.group_add)
     async def add_group(self, inter, name: str):
+        group = group_repo.get_group(name)
+        if group is not None:
+            await inter.send(f"Groupa s názvem {name} už existuje.")
+            return
         group_repo.add_group(name)
-        await inter.send(f"Pridal jsem groupu {name}")
+        await inter.send(f"Pridal jsem groupu {name}.")
 
     @group.sub_command(name="get", description=Messages.group_get)
     async def get_group(self, inter, name: str):
@@ -273,8 +277,11 @@ class Roles(commands.Cog):
     @group.sub_command(name="list", description=Messages.group_list)
     async def groups(self, inter):
         names = group_repo.group_names()
-        for name in names:
-            await inter.send(name)
+        groups = '\n'.join([str(name) for name in names])
+        output = utils.cut_string(groups, 1900)
+        output[0] = f"```md\n# ACTIVE GROUPS:\n{output[0]}```"
+        for message in output:
+            await inter.send(message)
 
     @group.sub_command(name="add_channel_id", description=Messages.group_add_channel_id)
     async def add_channel_id(self, inter, name: str, channel_id: str):

--- a/utils.py
+++ b/utils.py
@@ -118,6 +118,21 @@ def split_to_parts(items, size: int):
     return result
 
 
+def cut_string_by_words(string: str, part_len: int, delimiter: str):
+    """returns list of strings with length of part_len, only whole words"""
+    result = []
+    while True:
+        if len(string) < part_len:
+            result.append(string)
+            break
+        chunk = string[:part_len]
+        last_delimiter = chunk.rindex(delimiter)    # get index of last delimiter
+        chunk = chunk[:last_delimiter]
+        result.append(chunk)
+        string = string[len(chunk):]
+    return result
+
+
 class NotHelperPlusError(commands.CommandError):
     """An error indicating that a user doesn't have permissions to use
     a command that is available only to helpers, submods and mods.


### PR DESCRIPTION
group list outputs groups now in single message or cuts it in multiple if necessary
group add didn't have check for adding group with same name, now fixed
fix #460 