### PR TITLE
fix discord no-access fuckup

### DIFF
--- a/features/bookmark.py
+++ b/features/bookmark.py
@@ -20,7 +20,7 @@ class BookmarkFeatures():
         embed.set_image(image)
         embed.add_field(
             name="Channel",
-            value=f"{inter.message.channel.mention}"
+            value=f"{inter.message.channel.mention} - #{inter.message.channel}"
         )
         return embed
 
@@ -72,6 +72,6 @@ class BookmarkFeatures():
             embed.add_field(name="Poznámka", value=Messages.bookmark_upload_limit, inline=False)
         embed.add_field(
             name="Channel",
-            value=f"{inter.message.channel.mention}"
+            value=f"{inter.message.channel.mention} - #{inter.message.channel}"
         )
         return ([embed], images, files_attached)


### PR DESCRIPTION
when using mention of channel users who don't see the channel have name "no-access" instead of actual name room