### PR TITLE
Don't load `name_day` cog by default

### DIFF
--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -26,7 +26,7 @@ db_string = "postgresql://postgres:postgres@db:5432/postgres"
 
 [cogs]
 extensions = ['base', 'karma', 'meme', 'random', 'verify', 'fitwide', 'autopin', 'help',
-    'acl', 'review', 'vote', 'name_day', 'week', 'roles', 'error', 'absolvent', 'pet', 'reactions',
+    'acl', 'review', 'vote', 'week', 'roles', 'error', 'absolvent', 'pet', 'reactions',
     'streamlinks', 'bookmark', 'subscriptions', 'latex', 'info', 'fun', 'moderation']
 
 [config]


### PR DESCRIPTION
Remove `name_day` from config template so new forks won't trigger GrillBot API by default.