### PR TITLE
Add dev container config and instructions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "Existing Docker Compose (Extend)",
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+	"service": "bot",
+	"workspaceFolder": "/rubbergod"
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ git clone https://github.com/toaster192/rubbergod.git
 cd rubbergod
 ```
 
+## Dev containers vscode (one click run)
+
+If you are using vscode you can simply run Rubbergod by using Dev containers extension. Either by clicking on notification or by clicking on arrows in left bottom corner (Open a Remote Window) and choosing `Reopen in container`.
+
 ## Docker compose setup (recomended)
 
 Install `docker` and `docker-compose` for your system (will vary from system to system)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     bot:
         build: .
         volumes:
-            - ./config/config.toml:/rubbergod/config/config.toml
+            - .:/rubbergod:Z
         depends_on:
             - db
 


### PR DESCRIPTION
This should allow users to develop in containers easily by just clicking on one button in vscode.