### PR TITLE
remove rolehoarders command, get bot_owner

### DIFF
--- a/cogs/fitwide.py
+++ b/cogs/fitwide.py
@@ -31,36 +31,6 @@ class FitWide(commands.Cog):
             await channel.send(embed=gif)
 
     @cooldowns.default_cooldown
-    @commands.check(permission_check.submod_plus)
-    @commands.command()
-    async def rolehoarders(self, ctx, limit=config.rolehoarder_default_limit):
-        guild = self.bot.get_guild(config.guild_id)
-
-        found_members = []
-        for member in guild.members:
-            role_count = 0
-            for role in member.roles:
-                if role.name.lower() in config.subjects:
-                    role_count += 1
-            if role_count >= limit:
-                found_members.append((member, role_count))
-
-        msg = ""
-        if len(found_members) == 0:
-            msg = "Žádné jsem nenašel :slight_smile:"
-        else:
-            found_members.sort(key=lambda x: x[1], reverse=True)
-            for i, (member, role_count) in enumerate(found_members):
-                line = "{index}) <@{id}> - {count}\n".format(index=i + 1, id=member.id, count=role_count)
-                if len(line) + len(msg) >= 2000:
-                    await ctx.send(msg)
-                    msg = line
-                else:
-                    msg += line
-
-        await ctx.send(msg)
-
-    @cooldowns.default_cooldown
     @commands.check(permission_check.is_bot_admin)
     @commands.command()
     async def role_check(

--- a/cogs/grillbot_api.py
+++ b/cogs/grillbot_api.py
@@ -4,6 +4,7 @@ Functions and commands communicating with grillbot API
 
 import asyncio
 import json
+from functools import cached_property
 from io import BytesIO
 
 import aiohttp
@@ -18,9 +19,14 @@ class GrillbotApi(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
+    @cached_property
+    async def bot_owner(self):
+        bot_owner = await self.bot.application_info()
+        return str(bot_owner.owner.id)
+
     async def post_karma_store(self, karma_objects):
         """send karma objects to grillbot api"""
-        headers = {"ApiKey": config.grillbot_api_key, "Author": str(self.bot.owner_id)}
+        headers = {"ApiKey": config.grillbot_api_key, "Author": await self.bot_owner}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10), headers=headers) as session:
             try:
                 url = "https://grillbot.cloud/api/user/karma/store"

--- a/cogs/name_day.py
+++ b/cogs/name_day.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import date, time
+from functools import cached_property
 
 import aiohttp
 import disnake
@@ -14,6 +15,11 @@ class Nameday(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.send_names.start()
+
+    @cached_property
+    async def bot_owner(self):
+        bot_owner = await self.bot.application_info()
+        return str(bot_owner.owner.id)
 
     async def _name_day_cz(self):
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
@@ -42,7 +48,7 @@ class Nameday(commands.Cog):
                 return "Website unreachable"
 
     async def _birthday(self):
-        headers = {"ApiKey": config.grillbot_api_key, "Author": str(self.bot.owner_id)}
+        headers = {"ApiKey": config.grillbot_api_key, "Author": await self.bot_owner}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10), headers=headers) as session:
             try:
                 url = "https://grillbot.cloud/api/user/birthday/today"

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -75,7 +75,7 @@ class Verify(commands.Cog):
         await inter.response.send_modal(modal)
 
     @commands.check(permission_check.submod_plus)
-    @commands.user_command(name="Verify host")
+    @commands.user_command(name="Verify host", guild_ids=[config.guild_id])
     async def verify_host(self, inter: disnake.UserCommandInteraction, member: disnake.Member):
         """add verify and host role to new member"""
         host_id = inter.guild.get_role(config.verification_host_id)

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -114,9 +114,6 @@ class Config:
     subject_mit_id_end: int = get_attr(toml_dict, "review", "mit_id_end")
     subject_mit_id_rnd: List[int] = get_attr(toml_dict, "review", "mit_id_rnd")
 
-    # How many roles a user needs to have to be considered a rolehoarder
-    rolehoarder_default_limit: int = get_attr(toml_dict, "rolehoarder", "default_limit")
-
     # memes
     hug_emojis: List[str] = get_attr(toml_dict, "meme", "hug_emojis")
     covid_channel_id: str = get_attr(toml_dict, "meme", "covid_channel_id")

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -110,10 +110,6 @@ mit_id_start = 14967
 mit_id_end = 14983
 mit_id_rnd = [15220]
 
-[rolehoarder]
-# How many people to print if the limit argument is not specified
-default_limit = 10
-
 [grillbot]
 #      Production,         Development
 ids = [902678773307174943, 599119578811072523]


### PR DESCRIPTION
remove rolehoarders command which doesn't work because of missing config and no longer usable as we switched to less roles managing
get bot owner different way, user command for guild only
