### PR TITLE
Change config.toml location.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bckup*
-config/config.toml
+/cfg
+config/external/config.toml
 __pycache__
 .idea
 .venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bckup*
 /cfg
+config/config.toml
 config/external/config.toml
 __pycache__
 .idea

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cd rubbergod
 #### Configuration
 
 ```bash
-cp config/config.template.toml config/config.toml
+cp config/config.template.toml config/external/config.toml
 ```
 
 Now open the `config.toml` file in your editor. Insert the Discord API key you obtained earlier in the setup process:

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -30,7 +30,7 @@ class Config:
     It checks value from config override and if not exists that will be take from config template.
     """
 
-    toml_dict: dict = toml.load("config/config.toml", _dict=dict)
+    toml_dict: dict = toml.load("config/external/config.toml", _dict=dict)
 
     # Authorization
     key: str = get_attr(toml_dict, "base", "key")

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -30,7 +30,10 @@ class Config:
     It checks value from config override and if not exists that will be take from config template.
     """
 
-    toml_dict: dict = toml.load("config/external/config.toml", _dict=dict)
+    try:
+        toml_dict: dict = toml.load("config/external/config.toml", _dict=dict)
+    except FileNotFoundError:
+        toml_dict: dict = toml.load("config/config.toml", _dict=dict)
 
     # Authorization
     key: str = get_attr(toml_dict, "base", "key")


### PR DESCRIPTION
Changed default location of config.toml file from config/config.toml to config/external/config.toml so now it can be easily imported from outside of container. The previous location is used as fallback.