### PR TITLE
feat(reviews): convert tiers to grades

### DIFF
--- a/buttons/review.py
+++ b/buttons/review.py
@@ -25,7 +25,10 @@ class ReviewView(EmbedView):
                 self.remove_item(button)
 
     def check_text_pages(self):
-        if len(self.embed.fields) > 3 and self.embed.fields[3].name == "Text page":
+        if (
+            len(self.embed.fields) > 3
+            and self.embed.fields[3].name == Messages.review_text_page_label
+        ):
             self.add_item(
                 disnake.ui.Button(
                     emoji="🔽",
@@ -96,7 +99,10 @@ class ReviewView(EmbedView):
                 # update view
                 await interaction.edit_original_response(view=self)
             return False
-        elif "text" in interaction.data.custom_id and self.embed.fields[3].name == "Text page":
+        elif (
+            "text" in interaction.data.custom_id and
+            self.embed.fields[3].name == Messages.review_text_page_label
+        ):
             if (self.perma_lock or self.locked) and interaction.author.id != self.author.id:
                 await interaction.send(Messages.embed_not_author, ephemeral=True)
                 return False

--- a/cogs/review.py
+++ b/cogs/review.py
@@ -96,7 +96,7 @@ class Review(Base, commands.Cog):
         self,
         inter: disnake.ApplicationCommandInteraction,
         subject: str = commands.Param(autocomplete=autocomp_subjects),
-        grade: str = commands.Param(choices=TierEnum._member_names_),
+        grade: str = commands.Param(choices=TierEnum._member_names_, description=Messages.review_grade_brief),
         text: str = commands.Param(),
         anonymous: bool = commands.Param(default=False)
     ):
@@ -297,8 +297,9 @@ class Review(Base, commands.Cog):
             output = ""
             cnt = 1
             for line in board:
-                # grade fromat: "B (1.7)"
-                grade = f"{TierEnum(round(line.avg_tier)).name}({round(line.avg_tier + 1, 1)})"
+                # grade format: "B (1.7)"
+                grade_num = TierEnum.tier_to_grade_num(line.avg_tier)
+                grade = f"{TierEnum(round(line.avg_tier)).name}({round(grade_num, 1)})"
                 output += f"{cnt} - **{line.shortcut}**: {grade}\n"
                 cnt += 1
             embed.description = output

--- a/config/messages.py
+++ b/config/messages.py
@@ -245,9 +245,9 @@ class Messages(metaclass=Formatable):
     review_remove_brief = "Odstraní hodnocení"
     review_list_brief = "Vypíše předměty, které si již ohodnotil"
     review_id_brief = "ID recenze, pouze pro administrátory"
+    review_grade_brief = "Známku, kterou by jsi dal předmětu od A-F (za organizaci, splnění očekávání, kvalitu výuky ...)"
 
     review_wrong_subject = "Nesprávná zkratka předmětu."
-    review_tier = "Známka je z rozsahu A-F, kde A je nejlepší."
     review_added = "Hodnocení předmětu bylo přidáno."
     reviews_reaction_help = "Pokud byla recenze užitečná dejte 👍, jinak 👎.\n" \
                             "Pro odstranění hlasu je možné použit 🛑.\n" \
@@ -261,13 +261,13 @@ class Messages(metaclass=Formatable):
     review_not_on_server = "{user}, na použití tohoto příkazu musíš být na FITwide serveru."
 
     # review embed
-    review_embed_description = "{name}\n**Průměrná známka:** {grade}"
-    review_embed_no_reviews = "*Zatim nic*"
+    review_embed_description = "{name}\n**Průměrná známka od studenta:** {grade}"
+    review_embed_no_reviews = "*Zatím nic*"
     review_text_label = "Text recenze"
     review_text_page_label = "Stránka textu"
-    review_author_lavel = "Autor"
-    review_grade_label = "Známka"
-    review_date_label = "Dátum"
+    review_author_label = "Autor"
+    review_grade_label = "Kvalita předmětu"
+    review_date_label = "Datum"
     review_other_reviews_label = "Další hodnocení"
     review_authored_list_label = "Ohodnotil jsi:"
 

--- a/config/messages.py
+++ b/config/messages.py
@@ -247,7 +247,7 @@ class Messages(metaclass=Formatable):
     review_id_brief = "ID recenze, pouze pro administrátory"
 
     review_wrong_subject = "Nesprávná zkratka předmětu."
-    review_tier = "Tier je z rozsahu 0-4, kde 0 je nejlepší."
+    review_tier = "Známka je z rozsahu A-F, kde A je nejlepší."
     review_added = "Hodnocení předmětu bylo přidáno."
     reviews_reaction_help = "Pokud byla recenze užitečná dejte 👍, jinak 👎.\n" \
                             "Pro odstranění hlasu je možné použit 🛑.\n" \
@@ -260,6 +260,17 @@ class Messages(metaclass=Formatable):
     review_add_denied = "{user}, na přidání hodnocení předmětu nemáš právo."
     review_not_on_server = "{user}, na použití tohoto příkazu musíš být na FITwide serveru."
 
+    # review embed
+    review_embed_description = "{name}\n**Průměrná známka:** {grade}"
+    review_embed_no_reviews = "*Zatim nic*"
+    review_text_label = "Text recenze"
+    review_text_page_label = "Stránka textu"
+    review_author_lavel = "Autor"
+    review_grade_label = "Známka"
+    review_date_label = "Dátum"
+    review_other_reviews_label = "Další hodnocení"
+    review_authored_list_label = "Ohodnotil jsi:"
+
     # review modal
     review_modal_title = "Přidat novou recenzi"
     review_subject_label = "Vyberte předmět"
@@ -271,7 +282,6 @@ class Messages(metaclass=Formatable):
     review_tier_2_desc = "Průměrný předmět"
     review_tier_3_desc = "Nic moc"
     review_tier_4_desc = "Nejhorší, celé zle"
-    review_text_label = "Text recenze"
 
     subject_update_biref = "Automaticky vyhledá a přidá předměty do reviews i subject databáze"
     subject_format = f"{prefix}subject [update]"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
Use grades A-F instead of confusing tiers 0-4, this should improve UX for users. I have also moved most of the Czech review texts to Messages.

## After checks (check all applicable)

- [x] PR was tested
- [x] CI is passing

## Post-deployment

- [x] Restart bot

## UI changes
<img width="616" alt="image" src="https://github.com/Toaster192/rubbergod/assets/43444182/5d1ad0af-6bf3-4b40-a00f-03d0b5a84cde">
