### PR TITLE
bug(memerepost): Spoiler images can't be in embed

### DIFF
--- a/config/messages.py
+++ b/config/messages.py
@@ -14,7 +14,7 @@ class Messages(metaclass=Formatable):
     karma_get_missing = "Toaster pls, měl jsi bordel v DB. Musel jsem za tebe uklidit."
 
     on_ready_message = "<:peepowave:693070888546861096>"
-    cooldown = "Příliš rychle, zkus to znovu za {:.3}s"
+    cooldown = "Příliš rychle, zkus to znovu za {time:.3}s"
     embed_not_author = "Hraj si na svém písečku s tebou zavolanými příkazy. <:pepeGun:826943455032901643>"
     base_leaderboard_format_str = "_{position}._ - **{member_name}**:"
 

--- a/utils.py
+++ b/utils.py
@@ -290,7 +290,7 @@ class PersistentCooldown:
                 )
             )
         elif (time_passed := now - current_cooldown.timestamp) < self.limit:
-            raise PCommandOnCooldown(Messages.cooldown((self.limit - time_passed) / 1000))
+            raise PCommandOnCooldown(Messages.cooldown(time=(self.limit - time_passed) / 1000))
         else:
             current_cooldown.timestamp = now
         session.commit()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [#] Bug Fix

## Description
Images with spoiler flag cant be in embed because then they lose the spoiler, instead they are sent as other_attachment

## After checks (check all applicable)

- [x] PR was tested
- [x] CI is passing

## [optional] Are there any post deployment tasks we need to perform?

- [x] Reload cog(s) [memerepost]
