### PR TITLE
fix(review): subject update command fix

### DIFF
--- a/cogs/README.md
+++ b/cogs/README.md
@@ -306,6 +306,7 @@ Cog implementing review system for subjects.\
     - /subject update
     - /wtf
     - /tierboard
+
 ---
 
 ### [Roles](roles.py)

--- a/config/messages.py
+++ b/config/messages.py
@@ -284,7 +284,7 @@ class Messages(metaclass=Formatable):
     review_tier_4_desc = "Nejhorší, celé zle"
 
     subject_update_biref = "Automaticky vyhledá a přidá předměty do reviews i subject databáze"
-    subject_format = f"{prefix}subject [update]"
+    subject_update_overwrite_brief = "Přepíše všechny informace o předmětech. Využít pouze v kombinaci s další aktualizací bez přepisu."
     subject_update_error = "Aktualizace se nezdařila pro <{url}>\n"
     subject_update_success = "Předměty byly aktualizovány."
     shortcut_brief = "Vrací stručné informace o předmětu"

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,6 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 from config.app_config import config
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
This PR fixes issue with updating subjects where sometimes wrong year/semester was assigned to subject. It was caused by change on the page where we are getting information about courses. Now I have added a check which is using table heading to parse year and semester information.

To enable removing old not correct data I have added a new parameter, that basically updates all subject in place. To update everything properly we need to first run with append argument set to false and then we can run it with True. This should not be needed in future but generally can help to avoid such issues as this one.

Also I took an opportunity to simplify the logic a bit and rework to slash command.

## After checks (check all applicable)

- [x] PR was tested
- [x] CI is passing

## Post deployment tasks

- [x] Restart bot
