### PR TITLE
Catch deleted messages in "Upgraded pocitani" thread

### DIFF
--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -36,6 +36,14 @@ class Meme(Base, commands.Cog):
         elif message.content == "PR":
             await message.channel.send(Messages.pr_meme)
 
+    @commands.Cog.listener()
+    async def on_raw_message_delete(self, payload: disnake.RawMessageDeleteEvent):
+        if payload.channel_id == self.config.upgraded_pocitani_thread_id:
+            pocitani = self.bot.get_channel(payload.channel_id)
+            startnum = self.config.upgraded_pocitani_start_num
+            await pocitani.send(Messages.upgraded_pocitani_caught_deleting)
+            await pocitani.send(startnum)
+
     @commands.slash_command(name="uhoh", description=Messages.uhoh_brief)
     async def uhoh(self, inter):
         await inter.send(Messages.uhoh_counter(uhohs=uhoh_counter))

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -117,6 +117,8 @@ class Config:
 
     # memes
     hug_emojis: List[str] = get_attr(toml_dict, "meme", "hug_emojis")
+    upgraded_pocitani_thread_id: int = get_attr(toml_dict, "meme", "upgraded_pocitani_thread_id")
+    upgraded_pocitani_start_num: int = get_attr(toml_dict, "meme", "upgraded_pocitani_start_num")
 
     # uh oh
     uhoh_string: str = get_attr(toml_dict, "meme", "uhoh_string")

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -80,6 +80,8 @@ image_extensions = ["png", "jpg", "jpeg", "gif"]
 
 [meme]
 uhoh_string = 'uh oh'
+upgraded_pocitani_thread_id = 1082751957288100042
+upgraded_pocitani_start_num = 1
 hug_emojis = ["<:peepoHug:600435649786544151>",
     "<:peepoHugger:602052621007585280>",
     "<:huggers:602823825880514561>", "(っ˘̩╭╮˘̩)っ", "(っ´▽｀)っ",

--- a/config/messages.py
+++ b/config/messages.py
@@ -54,6 +54,7 @@ class Messages(metaclass=Formatable):
     hug_hugboard_brief = "Celková tabulka statistiky obejmutí"
     hug_huggersboard_brief = "Vypíše nejčastější objímače"
     hug_mosthugged_brief = "Vypíše nejvíce objímané lidi"
+    upgraded_pocitani_caught_deleting = "Podvádět mazáním zpráv je zakázáno. Začínáme znovu: "
 
     # IOS
     ios_brief = "Připomene všem prasatům, že si mají jít po sobě uklidit"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] New Feature

## Description
The "Upgraded pocitani" thread in free for all forum channel is about resetting when a mistake happens and some people "cheat" by deleting their message.

This PR makes the bot automatically send "1" to the thread whenever anyone deletes any message.

## Related Tickets & Documents

- Closes #608

## After checks (check all applicable)

- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)
- [x] CI is passing

## [optional] Are there any post deployment tasks we need to perform?

- [ ] Update database
- [ ] Update packages, libraries, etc.
- [x] Change config
- [ ] Restart bot
- [x] Reload cog [Meme]

Note: although changing the config is not needed - new config option gets loaded on restart from the template instead - it is maybe desirable to keep `config.toml` up to date as much as we can?
