### PR TITLE
Review avg tier fix

### DIFF
--- a/buttons/embed.py
+++ b/buttons/embed.py
@@ -106,7 +106,11 @@ class EmbedView(BaseView):
         for child in self.children:
             if item.emoji == child.emoji:
                 return
-        return super().add_item(item)
+        try:
+            super().add_item(item)
+        except ValueError:
+            # catch random errors with adding buttons where we already have one
+            pass
 
     async def interaction_check(self, interaction: disnake.MessageInteraction) -> None:
         if interaction.data.custom_id == "embed:lock":

--- a/database/review.py
+++ b/database/review.py
@@ -29,17 +29,18 @@ class ReviewDB(database.base):
         return session.query(cls).filter(cls.id == id).one_or_none()
 
     @classmethod
-    def get_subject_reviews(cls, subject: str) -> List[ReviewDB]:
+    def get_subject_reviews(cls, subject: str) -> List[object]:
+        # return object with 'ReviewDB' and 'total' properties
         return (
             session.query(
                 cls,
-                func.avg(cls.tier).label("avg_tier"),
                 func.count(cls.relevance).filter(ReviewRelevanceDB.vote).label("total"),
             )
             .filter(cls.subject == subject)
             .outerjoin(cls.relevance)
             .group_by(cls)
             .order_by(desc("total"))
+            .all()
         )
 
     @classmethod

--- a/features/review.py
+++ b/features/review.py
@@ -1,5 +1,6 @@
 from datetime import datetime, time
 from enum import Enum
+from statistics import mean
 from typing import Union
 
 import disnake
@@ -158,7 +159,7 @@ class ReviewManager:
             if not subject_obj:
                 return None
         reviews = ReviewDB.get_subject_reviews(subject_obj.shortcut)
-        reviews_cnt = reviews.count()
+        reviews_cnt = len(reviews)
         subject_details = SubjectDetailsDB.get(subject_obj.shortcut) or subject_obj.shortcut
         name = getattr(subject_details, "name",  "")
         if reviews_cnt == 0:
@@ -166,10 +167,11 @@ class ReviewManager:
             return [self.make_embed(author, None, subject_details, description, "1/1")]
         else:
             embeds = []
+            avg_tier = mean([review.ReviewDB.tier for review in reviews])
             for idx in range(reviews_cnt):
                 review = reviews[idx].ReviewDB
-                grade_num = TierEnum.tier_to_grade_num(reviews[idx].avg_tier)
-                grade = f"{TierEnum(round(reviews[idx].avg_tier)).name}({round(grade_num, 1)})"
+                grade_num = TierEnum.tier_to_grade_num(avg_tier)
+                grade = f"{TierEnum(round(avg_tier)).name}({round(grade_num, 1)})"
                 description = Messages.review_embed_description(name=name, grade=grade)
                 page = f"{idx+1}/{reviews_cnt}"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
The average tier was not working because of 'GROUP BY' which resulted in SQL running AVG function per group (per review). I have moved the logic to python code instead. We are getting all reviews regardless, so I think it does not matter if you do the average on python or SQL level. I have not found a way how to do it in the same query.

I have also added a ignore for the constant error in adding buttons. I am still not able to reproduce it locally, so let's see what happens. Maybe we should remove the buttons in case of a error?

## Related Tickets & Documents
Closes #600

## After checks (check all applicable)

- [x] PR was tested

## Post deployment

- [x] Restart bot

