### PR TITLE
fix(reviews): disable buttons instead of removing if not needed

### DIFF
--- a/buttons/embed.py
+++ b/buttons/embed.py
@@ -105,6 +105,7 @@ class EmbedView(BaseView):
     def add_item(self, item: disnake.ui.Item) -> None:
         for child in self.children:
             if item.emoji == child.emoji:
+                child.disabled = False
                 return
         try:
             super().add_item(item)

--- a/buttons/review.py
+++ b/buttons/review.py
@@ -18,11 +18,8 @@ class ReviewView(EmbedView):
         self.check_text_pages()
         # if there aren't any reviews remove buttons
         if len(self.embed.fields) < 2:
-            to_remove = []
             for child in self.children:
-                to_remove.append(child)
-            for button in to_remove:
-                self.remove_item(button)
+                child.disabled = True
 
     def check_text_pages(self):
         if (
@@ -46,12 +43,9 @@ class ReviewView(EmbedView):
                 )
             )
         else:
-            to_remove = []
             for child in self.children:
                 if "text" in child.custom_id:
-                    to_remove.append(child)
-            for button in to_remove:
-                self.remove_item(button)
+                    child.disabled = True
 
     @property
     def review_id(self):


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
<!--
- [ ] Refactor/Enhancement
- [ ] New Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
-->
- [x] Bug Fix

## Description
<!--
Try to describe it as precisely as possible. You can add bullet list to point to specific tasks in this PR.
-->
Currently, buttons are removed when they are not relevant, e.g. review has no text pages. This PR will change this behavior to disable them instead of removing. Buttons are added when they are needed for the first time. I hope this will help to resolve the issues that we are seeing in this cog.

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->
None

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
<!--
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config

- [ ] Reload cog(s) [name(s)]
-->
- [x] Restart bot

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
