### PR TITLE
use edit thread for changing tags, add images/fiels to report

### DIFF
--- a/buttons/bookmark.py
+++ b/buttons/bookmark.py
@@ -15,5 +15,5 @@ class BookmarkView(BaseView):
             emoji="🗑",
             label="Smazat záložku",
             style=disnake.ButtonStyle.danger,
-            custom_id="bookmark:delete")
+            custom_id="trash:delete")
             )

--- a/cogs/bookmark.py
+++ b/cogs/bookmark.py
@@ -41,12 +41,6 @@ class Bookmark(Base, commands.Cog):
             )
             await ctx.member.send(files=files_attached[10:])
 
-    @commands.Cog.listener()
-    async def on_button_click(self, inter: disnake.MessageInteraction):
-        if inter.component.custom_id != "bookmark:delete":
-            return
-        await inter.message.delete()
-
 
 def setup(bot):
     bot.add_cog(Bookmark(bot))

--- a/config/messages.py
+++ b/config/messages.py
@@ -600,6 +600,7 @@ if ("Mám průměr pod 2.0")                                           \n  retur
     report_message_not_spam = "### Report #{id} unmarked as spam by @{author}"
     report_already_solved = "Report #{id} už byl uzavřen. V případě potřeby otevři další report"
     report_check_dm = "Odesílám report ..."
+    report_files_too_big = "Soubory přesahující upload limit:\n- {files}"
 
     # SUBSCRIPTIONS COG
     subscription_add_brief = "Přidá odběr na vlákna se zvoleným tagem"

--- a/features/report.py
+++ b/features/report.py
@@ -59,8 +59,7 @@ async def embed_resolved(
 
 async def set_tag(forum: disnake.ForumChannel, forum_thread: disnake.Thread, tag_name: str) -> None:
     """Remove all tags and add the tag with the given name"""
-    await forum_thread.remove_tags(*forum_thread.applied_tags)
     for tag in forum.available_tags:
         if tag.name.lower() == tag_name:
-            await forum_thread.add_tags(tag)
-            return
+            await forum_thread.edit(applied_tags=[tag])
+            break

--- a/utils.py
+++ b/utils.py
@@ -383,6 +383,7 @@ async def parse_attachments(
     message: disnake.Message
 ) -> Tuple[List[disnake.File], List[disnake.File], List[disnake.Attachment]]:
     """Parse attachments from message and return them as lists of disnake files
+    and if they are over 25MB as attachments.
 
     Returns
     -------


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix
- [x] Enhancement 

## Description
fix tags edit on report posts when sometimes because of asynchronous actions the post would have multiple tags applied
add files/images to report so we can see preview of whole message

## Related Issue(s)
none

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot
