### PR TITLE
fix `/diplom` command when user is not in verify db

### DIFF
--- a/cogs/absolvent.py
+++ b/cogs/absolvent.py
@@ -45,6 +45,13 @@ class Absolvent(Base, commands.Cog):
             can be discovered via https://dspace.vutbr.cz/handle/11012/19121
         """
         await inter.response.defer(with_message=True, ephemeral=True)
+
+        # check whether the user is verified
+        verify_role = inter.guild.get_role(self.config.verification_role_id)
+        if verify_role not in inter.author.roles:
+            await inter.edit_original_response(Messages.absolvent_not_verified)
+            return
+
         if thesis_web_id == "19121":
             await inter.edit_original_response(Messages.absolvent_id_from_help)
             return
@@ -69,6 +76,10 @@ class Absolvent(Base, commands.Cog):
         name_from_db = ValidPersonDB.get_user_by_id(inter.author.id).name
         # remove diacritics from the user-supplied name
         name_from_user_without_diacritics = remove_accents(f"{surname} {name}")
+
+        if name_from_db is None:
+            await inter.edit_original_response(Messages.absolvent_not_in_db)
+            return
 
         if name_from_db != name_from_user_without_diacritics:
             await inter.edit_original_response(Messages.absolvent_wrong_name)

--- a/config/messages.py
+++ b/config/messages.py
@@ -372,6 +372,8 @@ class Messages(metaclass=Formatable):
     absolvent_id_from_help = "Zadej svoje ID práce."
     absolvent_brief = "Příkaz pro ověření absolvování studia na FIT VUT"
     absolvent_help_brief = "Vypíše help k příkazu /diplom"
+    absolvent_not_in_db = "Tvůj login nebyl nalezen v databázi ověřených uživatelů. Použij příkaz `/verify` pro ověření (je zapotřebí školní email)."
+    absolvent_not_verified = "Pro zavolání tohoto příkazu je potřeba se ověřit pomocí příkazu `/verify`."
     absolvent_help = f"{absolvent_brief} - zadejte CASE-SENSITIVE údaje ve formátu:\n" \
         "/diplom <Titul.> <Jméno> <Příjmení> <Číslo diplomu> <ID kvalifikační práce z URL na webu knihovny VUT <https://dspace.vutbr.cz/handle/11012/19121> >\n" \
         "např: Bc. Josef Novák 123456/2019 99999\n" \


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix


## Description
when user would call `/diplom` command and wasn't in verify db it would raise exception.

## Related Issue(s)
- resolves #713 

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
- [x] Restart bot
