### PR TITLE
Add download of emojis and stickers

### DIFF
--- a/cogs/README.md
+++ b/cogs/README.md
@@ -68,6 +68,15 @@ Cog for dynamically changing config.\
     - /config update
 ---
 
+### [Emoji](emoji.py)
+
+Cog for managing server emojis. Download emojis and stickers. Get full size of emoji.\
+**Commands:**
+
+    - /get_emojis
+    - /get_emoji
+---
+
 ### [Error](error.py)
 
 Cog for handling command errors. This is mostly for logging purposes.

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -15,6 +15,10 @@ class Base:
         self.tasks = []
 
     @cached_property
+    def base_guild(self) -> disnake.TextChannel:
+        return self.bot.get_guild(Base.config.guild_id)
+
+    @cached_property
     def mod_room(self) -> disnake.TextChannel:
         return self.bot.get_channel(self.config.mod_room)
 

--- a/cogs/emoji.py
+++ b/cogs/emoji.py
@@ -1,0 +1,77 @@
+"""
+Cog for managing server emojis. Download emojis and stickers. Get full size of emoji.\
+"""
+
+import io
+import os
+import zipfile
+from datetime import time
+
+import disnake
+from disnake.ext import commands, tasks
+
+import utils
+from cogs.base import Base
+from config import cooldowns
+from config.messages import Messages
+from permissions import room_check
+
+
+class Emoji(Base, commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.check = room_check.RoomCheck(bot)
+        self.tasks = [self.download_emojis_task.start()]
+
+    async def download_emojis(self, guild: disnake.Guild):
+        """Download all emojis from server and save them to zip file"""
+        emojis = await guild.fetch_emojis()
+        stickers = await guild.fetch_stickers()
+        with zipfile.ZipFile("emojis.zip", "w") as zip_file:
+            for emoji in emojis:
+                with io.BytesIO() as image_binary:
+                    if emoji.animated:
+                        emoji_name = f"emojis/{emoji.name}.gif"
+                    else:
+                        emoji_name = f"emojis/{emoji.name}.png"
+                    await emoji.save(image_binary)
+                    zip_file.writestr(emoji_name, image_binary.getvalue())
+
+            for sticker in stickers:
+                with io.BytesIO() as image_binary:
+                    sticker_name = f"stickers/{sticker.name}.{sticker.format.name}"
+                    await sticker.save(image_binary)
+                    zip_file.writestr(sticker_name, image_binary.getvalue())
+
+    @cooldowns.default_cooldown
+    @commands.slash_command(name="emoji")
+    async def emoji(self, inter: disnake.ApplicationCommandInteraction):
+        await inter.response.defer(ephemeral=self.check.botroom_check(inter))
+
+    @cooldowns.default_cooldown
+    @emoji.sub_command(name="get_emojis", description=Messages.emoji_get_emojis_brief)
+    async def get_emojis(self, inter: disnake.ApplicationCommandInteraction):
+        """Get all emojis from server"""
+        if not os.path.exists("emojis.zip"):
+            await self.download_emojis(self.base_guild)
+        await inter.send(file=disnake.File("emojis.zip"))
+
+    @cooldowns.default_cooldown
+    @emoji.sub_command(name="get_emoji", description=Messages.emoji_get_emoji_brief)
+    async def get_emoji(self, inter: disnake.ApplicationCommandInteraction, emoji: disnake.PartialEmoji):
+        """Get emoji in full size"""
+        await inter.send(emoji.url)
+
+    @tasks.loop(time=time(5, 0, tzinfo=utils.get_local_zone()))
+    async def download_emojis_task(self):
+        await self.download_emojis(self.base_guild)
+
+    @get_emoji.error
+    async def emoji_errors(self, inter: disnake.ApplicationCommandInteraction, error):
+        if isinstance(error, commands.PartialEmojiConversionFailure):
+            await inter.send(Messages.emoji_not_emoji, ephemeral=True)
+            return True
+
+
+def setup(bot):
+    bot.add_cog(Emoji(bot))

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -29,7 +29,7 @@ db_string = "postgresql://postgres:postgres@db:5432/postgres"
 extensions = ['karma', 'meme', 'memerepost', 'random', 'verify', 'fitwide', 'autopin',
     'help', 'review', 'vote', 'week', 'roles', 'error', 'absolvent', 'gif', 'reactions',
     'streamlinks', 'bookmark', 'latex', 'info', 'fun', 'moderation', 'message',
-    'timeout', 'forum', 'report', 'contestvote']
+    'timeout', 'forum', 'report', 'contestvote', 'emoji']
 
 [config]
 static = ['config_static', 'toml_dict', 'key', 'weather_token', 'db_string']

--- a/config/messages.py
+++ b/config/messages.py
@@ -73,6 +73,11 @@ class Messages(metaclass=Formatable):
     bot_room_redirect = "{user} <:sadcat:576171980118687754> 👉 " \
                         "<#{bot_room}>\n"
 
+    # EMOJI
+    emoji_get_emojis_brief = "Pošle zip se všemi emoji a stickery ze serveru"
+    emoji_get_emoji_brief = "Zobrazí emoji v plné velikosti"
+    emoji_not_emoji = "Neplatný formát emoji"
+
     # MEME
     uhoh_counter = "{uhohs} uh ohs od spuštění."
     uhoh_brief = "Vypíše počet uh ohs od spuštění"


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] New Feature

## Description
For now only for getting emojis and stickers from the VUT server. Versioning might be possible later. I don't think it's worth right now. Open to discussion if we want to have the zip updated everytime emojis change migth be counter productive if there was a problem with server but i think it can be enough just pinning the zip in channel.

## Related Issue(s)
- Related Issue #503 

## After checks
<!-- check all applicable -->
- [x] PR was tested

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
![image](https://github.com/Toaster192/rubbergod/assets/56552845/277ba248-b3fe-437f-8bc3-c7f56be4c931)
