### PR TITLE
Make `/pin get_all` always ephemeral

### DIFF
--- a/cogs/autopin.py
+++ b/cogs/autopin.py
@@ -123,7 +123,7 @@ class AutoPin(Base, commands.Cog):
     @cooldowns.long_cooldown
     @commands.slash_command(name="pin")
     async def pin(self, inter: disnake.ApplicationCommandInteraction):
-        await inter.response.defer(ephemeral=self.check.botroom_check(inter))
+        await inter.response.defer(ephemeral=True)
 
     @pin.sub_command(name="get_all", description=Messages.autopin_get_all_brief)
     async def get_all(


### PR DESCRIPTION
## PR type
- [ ] Refactor/Enhancement
- [ ] New Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As described in #734 , `/pin get_all` could, under certain conditions, leak pins in private channels. This PR fixes the problem by making `/pin get_all` always ephemeral (only visible to the caller).

## Related Issue(s)
- Resolves #734 

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [x] Reload cog(s) [autopin]
