### PR TITLE
trying new method for keeping images from reports

### DIFF
--- a/buttons/report.py
+++ b/buttons/report.py
@@ -114,7 +114,7 @@ class ReportView(BaseView):
 
         await report_author.send(embed=embed_user)
         await inter.message.channel.send(embed=embed)
-        await inter.edit_original_response(embed=embed, view=self, attachments=None)
+        await inter.edit_original_response(content=None, embed=embed, view=self)
 
     @disnake.ui.button(
         label="Send answer",


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
Right now the attachments that are sent with message dissappear after certain time the original message is deleted. This should have been prevented by uploading the file but with another bug it seems i created it once more. This should keep the attachments available even after deletion of original message and not cause showing the attachments inside of embed and also outside.

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot


## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
