### PR TITLE
compose rework

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,9 @@ services:
     bot:
         deploy:
             restart_policy:
-                condition: on-failure
+                condition: unless-stopped
                 delay: 5s
                 window: 20s
-                max_attempts: 3
         build: .
         volumes:
             - .:/rubbergod:Z


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
With before the maximum retries meant all of the time now in specific window, so shutting down the bot 3 times would result in one of us going to server and running it again. This should make more usable as it will try running it for 60s if it fails don't continue.

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Change config
- [x] Restart bot


## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
