### PR TITLE
animal commands return file instead of url

### DIFF
--- a/config/messages.py
+++ b/config/messages.py
@@ -19,6 +19,7 @@ class Messages(metaclass=Formatable):
     base_leaderboard_format_str = "_{position}._ - **{member_name}**:"
     invalid_time_format = "Neplatný formát času.\n{time_format}."
     attachment_too_big = "Příloha je příliš velká. Maximální velikost je 25 MB."
+    api_error = "Nepovedlo se získat data z API\n{error}"
 
     # FITWIDE
     increment_roles_brief = "Aktualizuje role na serveru podle ročníku. Aktualizace školních roomek."

--- a/features/error.py
+++ b/features/error.py
@@ -340,6 +340,10 @@ class ErrorLogger:
             await ctx.send(Messages.message_not_found, ephemeral=True)
             return True
 
+        if isinstance(error, custom_errors.ApiError):
+            await ctx.send(error.message)
+            return
+
         # LEGACY COMMANDS
         if (
             isinstance(error, commands.BadArgument)

--- a/permissions/custom_errors.py
+++ b/permissions/custom_errors.py
@@ -5,7 +5,12 @@ from config.messages import Messages
 
 
 class InvalidTime(commands.CommandError):
-    """An error indicating that the time format is invalid.
-    """
+    """An error indicating that the time format is invalid."""
     def __init__(self, time_format: str) -> None:
         self.message = Messages.invalid_time_format(time_format=time_format)
+
+
+class ApiError(commands.CommandError):
+    """An error indicating that the api returned invalid status."""
+    def __init__(self, error: str) -> None:
+        self.message = Messages.api_error(error=error)


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
we encountered that page sometimes returned malfunction URLs. Now it should instead retrieve image and send it so it stays or returns error that API is broken.

## Related Issue(s)
- Resolves #738

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot


## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
