### PR TITLE
fix print of top contributions, add subcommands to error handling

### DIFF
--- a/cogs/contestvote.py
+++ b/cogs/contestvote.py
@@ -51,7 +51,7 @@ class ContestVote(Base, commands.Cog):
         name="calculate_contribution",
         description=Messages.contest_vote_calculate_contribution_brief
     )
-    async def calculate_message(
+    async def calculate_contribution(
         self,
         inter: disnake.ApplicationCommandInteraction,
         message_url: disnake.Message
@@ -74,12 +74,16 @@ class ContestVote(Base, commands.Cog):
     async def top_contributions(
         self,
         inter: disnake.ApplicationCommandInteraction,
-        number_of=commands.Param(default=5, gt=0, description=Messages.contest_vote_top_count_brief)
+        number_of: int = commands.Param(default=5, gt=0, description=Messages.contest_vote_top_count_brief)
     ):
         await inter.response.defer(ephemeral=self.check.botroom_check(inter))
         messages = await self.contest_vote_channel.history().flatten()
 
         contributions = await get_top_contributions(self, messages, number_of)
+
+        if not contributions:
+            await inter.send(Messages.contest_vote_no_contributions)
+            return
 
         await inter.send(
             Messages.contest_vote_top_contributions(

--- a/config/messages.py
+++ b/config/messages.py
@@ -360,6 +360,7 @@ class Messages(metaclass=Formatable):
     contest_vote_top_count_brief = "Počet top příspěvků"
     contest_vote_top_contributions = "# Top {number_of} příspěvků\n{contributions}"
     contest_vote_invalid_votes = "**Počet neplatných hlasů (vybráno více možností): {invalid_votes}**"
+    contest_vote_no_contributions = "Nebyly nalezeny žádné příspěvky s body"
 
     # REVIEW
     review_add_brief = "Přidá recenzi na předmět. Pokud jsi již recenzi na předmět napsal, bude nahrazena novou."

--- a/features/error.py
+++ b/features/error.py
@@ -137,7 +137,10 @@ class ErrorLogger:
             return "User command - "
         elif isinstance(command, commands.InvokableMessageCommand):
             return "Message command - "
-        elif isinstance(command, commands.InvokableSlashCommand):
+        elif (
+            isinstance(command, commands.InvokableSlashCommand)
+            or isinstance(command, commands.slash_core.SubCommand)
+        ):
             return "/"
         else:
             # some new command probably? there aren't other options at the moment


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix


## Description
error handling didnt catch subcommands
printing of top contributions was missing the typing hint which was neccessary

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot


## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
