### PR TITLE
rework delete message in report

### DIFF
--- a/config/messages.py
+++ b/config/messages.py
@@ -662,6 +662,7 @@ if ("Mám průměr pod 2.0")                                           \n  retur
     report_modal_success = "Report byl úspěšně odeslán"
     report_answer = "Zadej zprávu pro uživatele"
     report_answer_title = "Answer to report #{id}"
+    report_message_deleted_title = "Report #{id} - Message deleted"
     report_answer_success = "Zpráva byla úspěšně odeslána"
     report_banned = "Bylo ti zakázáno posílat reporty z důvodu spamu falešných reportů. Pro další řešení kontaktuj moderátory"
     report_unban_user_brief = "Povolí uživateli posílat reporty"

--- a/features/report.py
+++ b/features/report.py
@@ -1,8 +1,13 @@
 import re
+from datetime import datetime, timezone
 from typing import Optional
 
 import disnake
 from disnake.ext import commands
+
+import utils
+from config.messages import Messages
+from database.report import ReportDB
 
 
 def extract_report_id(inter: disnake.MessageInteraction) -> int:
@@ -18,6 +23,14 @@ async def convert_url(inter, message_url) -> Optional[disnake.Message]:
     except commands.MessageNotFound:
         message = None
     return message
+
+
+async def set_tag(forum: disnake.ForumChannel, forum_thread: disnake.Thread, tag_name: str) -> None:
+    """Remove all tags and add the tag with the given name"""
+    for tag in forum.available_tags:
+        if tag.name.lower() == tag_name:
+            await forum_thread.edit(applied_tags=[tag])
+            break
 
 
 async def embed_resolved(
@@ -57,9 +70,42 @@ async def embed_resolved(
     return embed
 
 
-async def set_tag(forum: disnake.ForumChannel, forum_thread: disnake.Thread, tag_name: str) -> None:
-    """Remove all tags and add the tag with the given name"""
-    for tag in forum.available_tags:
-        if tag.name.lower() == tag_name:
-            await forum_thread.edit(applied_tags=[tag])
-            break
+def answer_embed(title, inter: disnake.ModalInteraction, report: ReportDB, answer: str) -> disnake.Embed:
+    """creates an embed template for the submitted answer"""
+    description = Messages.report_embed_answered(last_answer=report.last_answer, answer=answer)
+    embed = disnake.Embed(
+        title=title,
+        description=description,
+        color=disnake.Color.yellow()
+    )
+
+    if inter.channel.type == disnake.ChannelType.private:
+        author = "Anonym"
+        embed.timestamp = datetime.now(tz=timezone.utc)
+        embed.set_footer(
+            icon_url=inter.author.default_avatar.url,
+            text=f"{author} | ID: {report.id}"
+        )
+
+    else:
+        author = f"{inter.author.mention} @{inter.author.display_name}"
+        utils.add_author_footer(embed, inter.author, additional_text=[f"ID: {report.id}"])
+
+    embed.add_field(name="Answered by", value=author, inline=False)
+    return embed
+
+
+def deleted_message_embed(
+    inter: disnake.ModalInteraction,
+    report: ReportDB,
+    description: str
+) -> disnake.Embed:
+    """creates an embed template for the submitted answer"""
+    embed = disnake.Embed(
+        title=Messages.report_message_deleted_title(id=report.id),
+        description=description,
+        color=disnake.Color.yellow()
+    )
+
+    utils.add_author_footer(embed, inter.author, additional_text=[f"ID: {report.id}"])
+    return embed


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Refactor/Enhancement

## Description
deleted message in report system is now embed and user is able to resolve after the message is deleted

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [x] PR was tested

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot


## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
![image](https://github.com/Toaster192/rubbergod/assets/56552845/c8c4697d-b7ef-4d09-b156-ba3cc4357a07)
