### PR TITLE
add graphviz to docker dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 ENV TZ=Europe/Prague
 
-RUN apk update && apk add gcc git postgresql-dev musl-dev tzdata libxml2-dev libxslt-dev g++ openssh
+RUN apk update && apk add gcc git postgresql-dev musl-dev tzdata libxml2-dev libxslt-dev g++ openssh python3-dev graphviz-dev graphviz
 RUN apk add jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev libwebp-dev libffi-dev cairo
 
 VOLUME /rubbergod


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
sometimes it appears that the docker is missing graphviz. I don't know why or when but it happened to me and @Misha12 in past. With this it should be fixed for the future.

## Related Issue(s)
None
## After checks
<!-- check all applicable -->
- [x] PR was tested
- [x] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot
